### PR TITLE
Add contributing guidelines and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,31 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: '[BUG] '
+labels: 'bug'
+assignees: ''
+---
+
+## Describe the bug
+<!-- A clear and concise description of what the bug is -->
+
+## To Reproduce
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+## Expected behavior
+<!-- A clear and concise description of what you expected to happen -->
+
+## Screenshots
+<!-- If applicable, add screenshots to help explain your problem -->
+
+## Environment
+ - OS: [e.g. iOS, Windows, Linux]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+## Additional context
+<!-- Add any other context about the problem here --> 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,22 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: '[FEATURE] '
+labels: 'enhancement'
+assignees: ''
+---
+
+## Is your feature request related to a problem? Please describe.
+<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
+
+## Describe the solution you'd like
+<!-- A clear and concise description of what you want to happen -->
+
+## Example use case
+<!-- Provide an example of how you imagine this feature would work in practice -->
+
+## Describe alternatives you've considered
+<!-- A clear and concise description of any alternative solutions or features you've considered -->
+
+## Additional context
+<!-- Add any other context or screenshots about the feature request here --> 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,30 @@
+# Pull Request
+
+## Description
+<!-- Provide a brief description of your changes -->
+
+## Related Issue
+<!-- Link to the related issue if applicable -->
+Fixes #
+
+## Type of Change
+<!-- Mark with an `x` all the boxes that apply -->
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation update
+- [ ] Other (please describe):
+
+## Checklist
+<!-- Mark with an `x` all the boxes that apply -->
+- [ ] My code follows the code style of this project
+- [ ] I have tested my changes locally
+- [ ] I have updated the documentation accordingly
+- [ ] My changes don't break existing functionality
+- [ ] I have added tests that prove my fix/feature works
+
+## Screenshots
+<!-- If applicable, add screenshots to help explain your changes -->
+
+## Additional Notes
+<!-- Add any other information about the PR here --> 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,46 @@
+# Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes
+* Focusing on what is best for the community
+
+Examples of unacceptable behavior:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement
+
+Violations of the code of conduct may be reported to the project team. All
+complaints will be reviewed and investigated promptly and fairly.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, issues, and other contributions that are
+not aligned with this Code of Conduct.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org),
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html. 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,58 @@
+# Contributing to GeoWeaver
+
+Thank you for your interest in contributing to GeoWeaver! We're excited to welcome community contributions as we build this project together.
+
+## Getting Started
+
+### Issues
+
+- Check existing issues before creating a new one
+- Use the issue templates when reporting bugs or requesting features
+- Be clear and provide as much information as possible
+
+### Pull Requests
+
+- Create a branch for your changes (don't commit directly to `main`)
+- Make your changes focused and keep them to a single concern
+- Follow existing code style and conventions
+- Include tests for new functionality when possible
+- Update documentation as needed
+
+## Development Workflow
+
+1. Fork the repository
+2. Create a new branch from `main` for your changes
+3. Make your changes
+4. Test your changes
+5. Submit a pull request
+
+## Code Style
+
+- Follow the existing code style in the project
+- Use meaningful variable and function names
+- Include comments for complex logic
+
+## Commit Messages
+
+- Use clear, descriptive commit messages
+- Start with a brief summary line
+- Add more detailed explanation if necessary
+- Reference issue numbers when applicable
+
+## Review Process
+
+- All contributions require review before merging
+- Be responsive to feedback and questions
+- Be patient, as reviews may take some time
+
+## Community Guidelines
+
+- Be respectful and inclusive in all interactions
+- Focus on constructive feedback
+- Help others when you can
+
+## Questions?
+
+If you have any questions or need assistance, please open an issue or reach out to the project maintainers.
+
+We appreciate all contributions, whether it's code, documentation, bug reports, or feature suggestions! 

--- a/README.md
+++ b/README.md
@@ -146,6 +146,12 @@ docker-compose -f dev.docker-compose.yml up --build
 - **Docker**: Container platform
 - **Nginx**: Web server and reverse proxy
 
+## Contributing
+
+We welcome contributions from the community! If you're interested in helping improve GeoWeaver, please check out our [Contributing Guide](CONTRIBUTING.md) for information on how to get started.
+
+Please also review our [Code of Conduct](CODE_OF_CONDUCT.md) to ensure a positive and inclusive environment for all contributors.
+
 ## License
 
 This project is licensed under the MIT License - see the LICENSE file for details.


### PR DESCRIPTION
## Summary
This PR adds community contribution documents to make it easier for new contributors to get involved the NaLaMap project. Contributes to #73 

## Changes
- Added `CONTRIBUTING.md` with clear guidelines for contributors
- Created `CODE_OF_CONDUCT.md` based on Contributor Covenant
- Added issue templates for bug reports and feature requests
- Added pull request template for standardized submissions
- Updated README.md with links to contribution guidelines
