### PR TITLE
Features/20250823 custom geoservers integration

### DIFF
--- a/backend/models/geodata.py
+++ b/backend/models/geodata.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Dict, List, NamedTuple, Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 
 class DataType(str, Enum):
@@ -86,11 +86,11 @@ class GeoDataObject(BaseModel):
     selected: Optional[bool] = False
     style: Optional[LayerStyle] = None
 
-    class Config:
-        # Allow Enum values to be output as raw values
-        use_enum_values = True
-        # Any extra fields in input will be ignored
-        extra = "ignore"
+    # Pydantic v2: use `model_config` with ConfigDict instead of class Config
+    model_config = ConfigDict(
+        use_enum_values=True,
+        extra="ignore",
+    )
 
 
 def mock_geodata_objects() -> List[GeoDataObject]:

--- a/backend/models/geodata.py
+++ b/backend/models/geodata.py
@@ -82,7 +82,6 @@ class GeoDataObject(BaseModel):
     bounding_box: Optional[str] = None
     layer_type: Optional[str] = None
     properties: Optional[Dict[str, Any]] = {}
-    service_links: Optional[Dict[str, str]] = None
     visible: Optional[bool] = False
     selected: Optional[bool] = False
     style: Optional[LayerStyle] = None

--- a/backend/models/geodata.py
+++ b/backend/models/geodata.py
@@ -82,7 +82,7 @@ class GeoDataObject(BaseModel):
     bounding_box: Optional[str] = None
     layer_type: Optional[str] = None
     properties: Optional[Dict[str, Any]] = {}
-
+    service_links: Optional[Dict[str, str]] = None
     visible: Optional[bool] = False
     selected: Optional[bool] = False
     style: Optional[LayerStyle] = None

--- a/backend/models/geodata.py
+++ b/backend/models/geodata.py
@@ -9,6 +9,7 @@ class DataType(str, Enum):
     GEOJSON = "GeoJson"
     LAYER = "Layer"
     UPLOADED = "uploaded"
+    RASTER = "Raster"
 
 
 class DataOrigin(Enum):

--- a/backend/models/settings_model.py
+++ b/backend/models/settings_model.py
@@ -4,6 +4,8 @@ from pydantic import BaseModel, Field
 
 class GeoServerBackend(BaseModel):
     url: str = Field(..., description="GeoServer endpoint URL")
+    name: Optional[str] = Field(None, description="Human-friendly name for this backend")
+    description: Optional[str] = Field(None, description="Optional description / purpose notes")
     username: Optional[str] = Field(None, description="Basic auth username")
     password: Optional[str] = Field(None, description="Basic auth password")
     enabled: bool = Field(True, description="Enable or disable this backend")

--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -1984,6 +1984,138 @@ otel = ["opentelemetry-api (>=1.30.0,<2.0.0)", "opentelemetry-exporter-otlp-prot
 pytest = ["pytest (>=7.0.0)", "rich (>=13.9.4,<14.0.0)"]
 
 [[package]]
+name = "lxml"
+version = "6.0.1"
+description = "Powerful and Pythonic XML processing library combining libxml2/libxslt with the ElementTree API."
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "lxml-6.0.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:3b38e20c578149fdbba1fd3f36cb1928a3aaca4b011dfd41ba09d11fb396e1b9"},
+    {file = "lxml-6.0.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:11a052cbd013b7140bbbb38a14e2329b6192478344c99097e378c691b7119551"},
+    {file = "lxml-6.0.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:21344d29c82ca8547ea23023bb8e7538fa5d4615a1773b991edf8176a870c1ea"},
+    {file = "lxml-6.0.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:aa8f130f4b2dc94baa909c17bb7994f0268a2a72b9941c872e8e558fd6709050"},
+    {file = "lxml-6.0.1-cp310-cp310-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4588806a721552692310ebe9f90c17ac6c7c5dac438cd93e3d74dd60531c3211"},
+    {file = "lxml-6.0.1-cp310-cp310-manylinux_2_26_i686.manylinux_2_28_i686.whl", hash = "sha256:8466faa66b0353802fb7c054a400ac17ce2cf416e3ad8516eadeff9cba85b741"},
+    {file = "lxml-6.0.1-cp310-cp310-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:50b5e54f6a9461b1e9c08b4a3420415b538d4773bd9df996b9abcbfe95f4f1fd"},
+    {file = "lxml-6.0.1-cp310-cp310-manylinux_2_31_armv7l.whl", hash = "sha256:6f393e10685b37f15b1daef8aa0d734ec61860bb679ec447afa0001a31e7253f"},
+    {file = "lxml-6.0.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:07038c62fd0fe2743e2f5326f54d464715373c791035d7dda377b3c9a5d0ad77"},
+    {file = "lxml-6.0.1-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:7a44a5fb1edd11b3a65c12c23e1049c8ae49d90a24253ff18efbcb6aa042d012"},
+    {file = "lxml-6.0.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:a57d9eb9aadf311c9e8785230eec83c6abb9aef2adac4c0587912caf8f3010b8"},
+    {file = "lxml-6.0.1-cp310-cp310-win32.whl", hash = "sha256:d877874a31590b72d1fa40054b50dc33084021bfc15d01b3a661d85a302af821"},
+    {file = "lxml-6.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:c43460f4aac016ee0e156bfa14a9de9b3e06249b12c228e27654ac3996a46d5b"},
+    {file = "lxml-6.0.1-cp310-cp310-win_arm64.whl", hash = "sha256:615bb6c73fed7929e3a477a3297a797892846b253d59c84a62c98bdce3849a0a"},
+    {file = "lxml-6.0.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:c6acde83f7a3d6399e6d83c1892a06ac9b14ea48332a5fbd55d60b9897b9570a"},
+    {file = "lxml-6.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:0d21c9cacb6a889cbb8eeb46c77ef2c1dd529cde10443fdeb1de847b3193c541"},
+    {file = "lxml-6.0.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:847458b7cd0d04004895f1fb2cca8e7c0f8ec923c49c06b7a72ec2d48ea6aca2"},
+    {file = "lxml-6.0.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1dc13405bf315d008fe02b1472d2a9d65ee1c73c0a06de5f5a45e6e404d9a1c0"},
+    {file = "lxml-6.0.1-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:70f540c229a8c0a770dcaf6d5af56a5295e0fc314fc7ef4399d543328054bcea"},
+    {file = "lxml-6.0.1-cp311-cp311-manylinux_2_26_i686.manylinux_2_28_i686.whl", hash = "sha256:d2f73aef768c70e8deb8c4742fca4fd729b132fda68458518851c7735b55297e"},
+    {file = "lxml-6.0.1-cp311-cp311-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e7f4066b85a4fa25ad31b75444bd578c3ebe6b8ed47237896341308e2ce923c3"},
+    {file = "lxml-6.0.1-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:0cce65db0cd8c750a378639900d56f89f7d6af11cd5eda72fde054d27c54b8ce"},
+    {file = "lxml-6.0.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c372d42f3eee5844b69dcab7b8d18b2f449efd54b46ac76970d6e06b8e8d9a66"},
+    {file = "lxml-6.0.1-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:2e2b0e042e1408bbb1c5f3cfcb0f571ff4ac98d8e73f4bf37c5dd179276beedd"},
+    {file = "lxml-6.0.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:cc73bb8640eadd66d25c5a03175de6801f63c535f0f3cf50cac2f06a8211f420"},
+    {file = "lxml-6.0.1-cp311-cp311-win32.whl", hash = "sha256:7c23fd8c839708d368e406282d7953cee5134f4592ef4900026d84566d2b4c88"},
+    {file = "lxml-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:2516acc6947ecd3c41a4a4564242a87c6786376989307284ddb115f6a99d927f"},
+    {file = "lxml-6.0.1-cp311-cp311-win_arm64.whl", hash = "sha256:cb46f8cfa1b0334b074f40c0ff94ce4d9a6755d492e6c116adb5f4a57fb6ad96"},
+    {file = "lxml-6.0.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:c03ac546adaabbe0b8e4a15d9ad815a281afc8d36249c246aecf1aaad7d6f200"},
+    {file = "lxml-6.0.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:33b862c7e3bbeb4ba2c96f3a039f925c640eeba9087a4dc7a572ec0f19d89392"},
+    {file = "lxml-6.0.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7a3ec1373f7d3f519de595032d4dcafae396c29407cfd5073f42d267ba32440d"},
+    {file = "lxml-6.0.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:03b12214fb1608f4cffa181ec3d046c72f7e77c345d06222144744c122ded870"},
+    {file = "lxml-6.0.1-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:207ae0d5f0f03b30f95e649a6fa22aa73f5825667fee9c7ec6854d30e19f2ed8"},
+    {file = "lxml-6.0.1-cp312-cp312-manylinux_2_26_i686.manylinux_2_28_i686.whl", hash = "sha256:32297b09ed4b17f7b3f448de87a92fb31bb8747496623483788e9f27c98c0f00"},
+    {file = "lxml-6.0.1-cp312-cp312-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7e18224ea241b657a157c85e9cac82c2b113ec90876e01e1f127312006233756"},
+    {file = "lxml-6.0.1-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a07a994d3c46cd4020c1ea566345cf6815af205b1e948213a4f0f1d392182072"},
+    {file = "lxml-6.0.1-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:2287fadaa12418a813b05095485c286c47ea58155930cfbd98c590d25770e225"},
+    {file = "lxml-6.0.1-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b4e597efca032ed99f418bd21314745522ab9fa95af33370dcee5533f7f70136"},
+    {file = "lxml-6.0.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:9696d491f156226decdd95d9651c6786d43701e49f32bf23715c975539aa2b3b"},
+    {file = "lxml-6.0.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:e4e3cd3585f3c6f87cdea44cda68e692cc42a012f0131d25957ba4ce755241a7"},
+    {file = "lxml-6.0.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:45cbc92f9d22c28cd3b97f8d07fcefa42e569fbd587dfdac76852b16a4924277"},
+    {file = "lxml-6.0.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:f8c9bcfd2e12299a442fba94459adf0b0d001dbc68f1594439bfa10ad1ecb74b"},
+    {file = "lxml-6.0.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:1e9dc2b9f1586e7cd77753eae81f8d76220eed9b768f337dc83a3f675f2f0cf9"},
+    {file = "lxml-6.0.1-cp312-cp312-win32.whl", hash = "sha256:987ad5c3941c64031f59c226167f55a04d1272e76b241bfafc968bdb778e07fb"},
+    {file = "lxml-6.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:abb05a45394fd76bf4a60c1b7bec0e6d4e8dfc569fc0e0b1f634cd983a006ddc"},
+    {file = "lxml-6.0.1-cp312-cp312-win_arm64.whl", hash = "sha256:c4be29bce35020d8579d60aa0a4e95effd66fcfce31c46ffddf7e5422f73a299"},
+    {file = "lxml-6.0.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:485eda5d81bb7358db96a83546949c5fe7474bec6c68ef3fa1fb61a584b00eea"},
+    {file = "lxml-6.0.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:d12160adea318ce3d118f0b4fbdff7d1225c75fb7749429541b4d217b85c3f76"},
+    {file = "lxml-6.0.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:48c8d335d8ab72f9265e7ba598ae5105a8272437403f4032107dbcb96d3f0b29"},
+    {file = "lxml-6.0.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:405e7cf9dbdbb52722c231e0f1257214202dfa192327fab3de45fd62e0554082"},
+    {file = "lxml-6.0.1-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:299a790d403335a6a057ade46f92612ebab87b223e4e8c5308059f2dc36f45ed"},
+    {file = "lxml-6.0.1-cp313-cp313-manylinux_2_26_i686.manylinux_2_28_i686.whl", hash = "sha256:48da704672f6f9c461e9a73250440c647638cc6ff9567ead4c3b1f189a604ee8"},
+    {file = "lxml-6.0.1-cp313-cp313-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:21e364e1bb731489e3f4d51db416f991a5d5da5d88184728d80ecfb0904b1d68"},
+    {file = "lxml-6.0.1-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1bce45a2c32032afddbd84ed8ab092130649acb935536ef7a9559636ce7ffd4a"},
+    {file = "lxml-6.0.1-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:fa164387ff20ab0e575fa909b11b92ff1481e6876835014e70280769920c4433"},
+    {file = "lxml-6.0.1-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7587ac5e000e1594e62278422c5783b34a82b22f27688b1074d71376424b73e8"},
+    {file = "lxml-6.0.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:57478424ac4c9170eabf540237125e8d30fad1940648924c058e7bc9fb9cf6dd"},
+    {file = "lxml-6.0.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:09c74afc7786c10dd6afaa0be2e4805866beadc18f1d843cf517a7851151b499"},
+    {file = "lxml-6.0.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:7fd70681aeed83b196482d42a9b0dc5b13bab55668d09ad75ed26dff3be5a2f5"},
+    {file = "lxml-6.0.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:10a72e456319b030b3dd900df6b1f19d89adf06ebb688821636dc406788cf6ac"},
+    {file = "lxml-6.0.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b0fa45fb5f55111ce75b56c703843b36baaf65908f8b8d2fbbc0e249dbc127ed"},
+    {file = "lxml-6.0.1-cp313-cp313-win32.whl", hash = "sha256:01dab65641201e00c69338c9c2b8a0f2f484b6b3a22d10779bb417599fae32b5"},
+    {file = "lxml-6.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:bdf8f7c8502552d7bff9e4c98971910a0a59f60f88b5048f608d0a1a75e94d1c"},
+    {file = "lxml-6.0.1-cp313-cp313-win_arm64.whl", hash = "sha256:a6aeca75959426b9fd8d4782c28723ba224fe07cfa9f26a141004210528dcbe2"},
+    {file = "lxml-6.0.1-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:29b0e849ec7030e3ecb6112564c9f7ad6881e3b2375dd4a0c486c5c1f3a33859"},
+    {file = "lxml-6.0.1-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:02a0f7e629f73cc0be598c8b0611bf28ec3b948c549578a26111b01307fd4051"},
+    {file = "lxml-6.0.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:beab5e54de016e730875f612ba51e54c331e2fa6dc78ecf9a5415fc90d619348"},
+    {file = "lxml-6.0.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:92a08aefecd19ecc4ebf053c27789dd92c87821df2583a4337131cf181a1dffa"},
+    {file = "lxml-6.0.1-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:36c8fa7e177649470bc3dcf7eae6bee1e4984aaee496b9ccbf30e97ac4127fa2"},
+    {file = "lxml-6.0.1-cp314-cp314-manylinux_2_26_i686.manylinux_2_28_i686.whl", hash = "sha256:5d08e0f1af6916267bb7eff21c09fa105620f07712424aaae09e8cb5dd4164d1"},
+    {file = "lxml-6.0.1-cp314-cp314-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9705cdfc05142f8c38c97a61bd3a29581ceceb973a014e302ee4a73cc6632476"},
+    {file = "lxml-6.0.1-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:74555e2da7c1636e30bff4e6e38d862a634cf020ffa591f1f63da96bf8b34772"},
+    {file = "lxml-6.0.1-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:e38b5f94c5a2a5dadaddd50084098dfd005e5a2a56cd200aaf5e0a20e8941782"},
+    {file = "lxml-6.0.1-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a5ec101a92ddacb4791977acfc86c1afd624c032974bfb6a21269d1083c9bc49"},
+    {file = "lxml-6.0.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:5c17e70c82fd777df586c12114bbe56e4e6f823a971814fd40dec9c0de518772"},
+    {file = "lxml-6.0.1-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:45fdd0415a0c3d91640b5d7a650a8f37410966a2e9afebb35979d06166fd010e"},
+    {file = "lxml-6.0.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:d417eba28981e720a14fcb98f95e44e7a772fe25982e584db38e5d3b6ee02e79"},
+    {file = "lxml-6.0.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:8e5d116b9e59be7934febb12c41cce2038491ec8fdb743aeacaaf36d6e7597e4"},
+    {file = "lxml-6.0.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:c238f0d0d40fdcb695c439fe5787fa69d40f45789326b3bb6ef0d61c4b588d6e"},
+    {file = "lxml-6.0.1-cp314-cp314-win32.whl", hash = "sha256:537b6cf1c5ab88cfd159195d412edb3e434fee880f206cbe68dff9c40e17a68a"},
+    {file = "lxml-6.0.1-cp314-cp314-win_amd64.whl", hash = "sha256:911d0a2bb3ef3df55b3d97ab325a9ca7e438d5112c102b8495321105d25a441b"},
+    {file = "lxml-6.0.1-cp314-cp314-win_arm64.whl", hash = "sha256:2834377b0145a471a654d699bdb3a2155312de492142ef5a1d426af2c60a0a31"},
+    {file = "lxml-6.0.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:9283997edb661ebba05314da1b9329e628354be310bbf947b0faa18263c5df1b"},
+    {file = "lxml-6.0.1-cp38-cp38-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1beca37c6e7a4ddd1ca24829e2c6cb60b5aad0d6936283b5b9909a7496bd97af"},
+    {file = "lxml-6.0.1-cp38-cp38-manylinux_2_26_i686.manylinux_2_28_i686.whl", hash = "sha256:42897fe8cb097274087fafc8251a39b4cf8d64a7396d49479bdc00b3587331cb"},
+    {file = "lxml-6.0.1-cp38-cp38-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0ef8cd44a080bfb92776047d11ab64875faf76e0d8be20ea3ff0c1e67b3fc9cb"},
+    {file = "lxml-6.0.1-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:433ab647dad6a9fb31418ccd3075dcb4405ece75dced998789fe14a8e1e3785c"},
+    {file = "lxml-6.0.1-cp38-cp38-win32.whl", hash = "sha256:bfa30ef319462242333ef8f0c7631fb8b8b8eae7dca83c1f235d2ea2b7f8ff2b"},
+    {file = "lxml-6.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:7f36e4a2439d134b8e70f92ff27ada6fb685966de385668e21c708021733ead1"},
+    {file = "lxml-6.0.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:edb975280633a68d0988b11940834ce2b0fece9f5278297fc50b044cb713f0e1"},
+    {file = "lxml-6.0.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:d4c5acb9bc22f2026bbd0ecbfdb890e9b3e5b311b992609d35034706ad111b5d"},
+    {file = "lxml-6.0.1-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:47ab1aff82a95a07d96c1eff4eaebec84f823e0dfb4d9501b1fbf9621270c1d3"},
+    {file = "lxml-6.0.1-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:faa7233bdb7a4365e2411a665d034c370ac82798a926e65f76c26fbbf0fd14b7"},
+    {file = "lxml-6.0.1-cp39-cp39-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c71a0ce0e08c7e11e64895c720dc7752bf064bfecd3eb2c17adcd7bfa8ffb22c"},
+    {file = "lxml-6.0.1-cp39-cp39-manylinux_2_26_i686.manylinux_2_28_i686.whl", hash = "sha256:57744270a512a93416a149f8b6ea1dbbbee127f5edcbcd5adf28e44b6ff02f33"},
+    {file = "lxml-6.0.1-cp39-cp39-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e89d977220f7b1f0c725ac76f5c65904193bd4c264577a3af9017de17560ea7e"},
+    {file = "lxml-6.0.1-cp39-cp39-manylinux_2_31_armv7l.whl", hash = "sha256:0c8f7905f1971c2c408badf49ae0ef377cc54759552bcf08ae7a0a8ed18999c2"},
+    {file = "lxml-6.0.1-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:ea27626739e82f2be18cbb1aff7ad59301c723dc0922d9a00bc4c27023f16ab7"},
+    {file = "lxml-6.0.1-cp39-cp39-musllinux_1_2_armv7l.whl", hash = "sha256:21300d8c1bbcc38925aabd4b3c2d6a8b09878daf9e8f2035f09b5b002bcddd66"},
+    {file = "lxml-6.0.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:021497a94907c5901cd49d24b5b0fdd18d198a06611f5ce26feeb67c901b92f2"},
+    {file = "lxml-6.0.1-cp39-cp39-win32.whl", hash = "sha256:620869f2a3ec1475d000b608024f63259af8d200684de380ccb9650fbc14d1bb"},
+    {file = "lxml-6.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:afae3a15889942426723839a3cf56dab5e466f7d873640a7a3c53abc671e2387"},
+    {file = "lxml-6.0.1-cp39-cp39-win_arm64.whl", hash = "sha256:2719e42acda8f3444a0d88204fd90665116dda7331934da4d479dd9296c33ce2"},
+    {file = "lxml-6.0.1-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:0abfbaf4ebbd7fd33356217d317b6e4e2ef1648be6a9476a52b57ffc6d8d1780"},
+    {file = "lxml-6.0.1-pp310-pypy310_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1ebbf2d9775be149235abebdecae88fe3b3dd06b1797cd0f6dffe6948e85309d"},
+    {file = "lxml-6.0.1-pp310-pypy310_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a389e9f11c010bd30531325805bbe97bdf7f728a73d0ec475adef57ffec60547"},
+    {file = "lxml-6.0.1-pp310-pypy310_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8f5cf2addfbbe745251132c955ad62d8519bb4b2c28b0aa060eca4541798d86e"},
+    {file = "lxml-6.0.1-pp310-pypy310_pp73-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f1b60a3287bf33a2a54805d76b82055bcc076e445fd539ee9ae1fe85ed373691"},
+    {file = "lxml-6.0.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:f7bbfb0751551a8786915fc6b615ee56344dacc1b1033697625b553aefdd9837"},
+    {file = "lxml-6.0.1-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:b556aaa6ef393e989dac694b9c95761e32e058d5c4c11ddeef33f790518f7a5e"},
+    {file = "lxml-6.0.1-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:64fac7a05ebb3737b79fd89fe5a5b6c5546aac35cfcfd9208eb6e5d13215771c"},
+    {file = "lxml-6.0.1-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:038d3c08babcfce9dc89aaf498e6da205efad5b7106c3b11830a488d4eadf56b"},
+    {file = "lxml-6.0.1-pp311-pypy311_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:445f2cee71c404ab4259bc21e20339a859f75383ba2d7fb97dfe7c163994287b"},
+    {file = "lxml-6.0.1-pp311-pypy311_pp73-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e352d8578e83822d70bea88f3d08b9912528e4c338f04ab707207ab12f4b7aac"},
+    {file = "lxml-6.0.1-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:51bd5d1a9796ca253db6045ab45ca882c09c071deafffc22e06975b7ace36300"},
+    {file = "lxml-6.0.1.tar.gz", hash = "sha256:2b3a882ebf27dd026df3801a87cf49ff791336e0f94b0fad195db77e01240690"},
+]
+
+[package.extras]
+cssselect = ["cssselect (>=0.7)"]
+html-clean = ["lxml_html_clean"]
+html5 = ["html5lib"]
+htmlsoup = ["BeautifulSoup4"]
+
+[[package]]
 name = "marshmallow"
 version = "3.26.1"
 description = "A lightweight library for converting complex datatypes to and from native Python datatypes."
@@ -2426,6 +2558,24 @@ files = [
     {file = "ormsgpack-1.10.0-cp39-cp39-win_amd64.whl", hash = "sha256:106253ac9dc08520951e556b3c270220fcb8b4fef0d30b71eedac4befa4de749"},
     {file = "ormsgpack-1.10.0.tar.gz", hash = "sha256:7f7a27efd67ef22d7182ec3b7fa7e9d147c3ad9be2a24656b23c989077e08b16"},
 ]
+
+[[package]]
+name = "owslib"
+version = "0.34.1"
+description = "OGC Web Service utility library"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "owslib-0.34.1-py3-none-any.whl", hash = "sha256:54ccde946f7732ac3be1408a35f9123ea9ffe794db2ef42d0d45294a5aa9e2f3"},
+    {file = "owslib-0.34.1.tar.gz", hash = "sha256:9c46d59dc03c753912fc3ef3136dbc843dad7572feb1af2cdf0fc5d1a0959028"},
+]
+
+[package.dependencies]
+lxml = "*"
+python-dateutil = "*"
+pyyaml = "*"
+requests = "*"
 
 [[package]]
 name = "packaging"
@@ -4665,4 +4815,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "0336c8f9d3db14ba981d5bc98f4e41ecdbe00a1af6c5d79f46e6529ceec900b0"
+content-hash = "6156798f08e3ac45609f26c594123a8e48ffb1a70b47a7b5cc69fcfd4ae775fc"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -18,6 +18,8 @@ openai = ">=1.63.0"
 psycopg = {extras = ["binary","pool"], version = ">=3.2.4"}
 langgraph = ">=0.2.73"
 langchain_openai = ">=0.3.12"
+owslib = "*"
+httpx = "*"
 
 langchain_google_genai = ">=2.0.5"
 langchain_mistralai = ">=0.2.2"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -92,7 +92,7 @@ filterwarnings = [
     "ignore::DeprecationWarning",
     "ignore::PendingDeprecationWarning"
 ]
-timeout = 300
+  # timeout removed: keep pytest config compatible with environments without pytest-timeout plugin
 
 [tool.black]
 line-length = 100

--- a/backend/services/default_agent_settings.py
+++ b/backend/services/default_agent_settings.py
@@ -1,5 +1,6 @@
 from typing import Dict
 from langchain_core.tools import BaseTool
+from services.tools.geoserver.custom_geoserver import get_custom_geoserver_data
 from services.tools.geocoding import (
     geocode_using_nominatim_to_geostate,
     geocode_using_overpass_to_geostate,
@@ -151,5 +152,6 @@ DEFAULT_AVAILABLE_TOOLS: Dict[str, BaseTool] = {
     "autostyle_new_layers": auto_style_new_layers,  # Intelligent auto-styling tool
     "check_and_autostyle": check_and_auto_style_layers,  # Automatic layer style checker
     "apply_color_scheme": apply_intelligent_color_scheme,
+    "get_custom_geoserver_data": get_custom_geoserver_data,
 }
 DEFAULT_SELECTED_TOOLS = []

--- a/backend/services/tools/geoserver/custom_geoserver.py
+++ b/backend/services/tools/geoserver/custom_geoserver.py
@@ -1,0 +1,195 @@
+"""
+This tool is used to get data from a custom GeoServer instance.
+It uses the GetCapabilities endpoint of a GeoServer to get a list of layers
+and their descriptions.
+"""
+
+import json
+import logging
+from typing import Any, Dict, List, Union
+from urllib.parse import urlencode
+
+from owslib.wms import WebMapService
+from langchain_core.messages import ToolMessage
+from langchain_core.tools import tool
+from langchain_core.tools.base import InjectedToolCallId
+from langgraph.prebuilt import InjectedState
+from typing_extensions import Annotated
+
+from models.geodata import DataOrigin, DataType, GeoDataObject
+from models.settings_model import GeoServerBackend, SettingsSnapshot
+from models.states import GeoDataAgentState
+
+logger = logging.getLogger(__name__)
+
+
+def parse_wms_capabilities(
+    wms: WebMapService, geoserver_url: str
+) -> List[GeoDataObject]:
+    """Parses the WMS GetCapabilities response and returns a list of GeoDataObjects."""
+    layers: List[GeoDataObject] = []
+    for layer_name, layer in wms.contents.items():
+        bounding_box = None
+        if layer.boundingBoxWGS84:
+            min_lon, min_lat, max_lon, max_lat = layer.boundingBoxWGS84
+            bounding_box = (
+                f"POLYGON(({max_lon} {min_lat}, {max_lon} {max_lat}, "
+                f"{min_lon} {max_lat}, {min_lon} {min_lat}, {max_lon} {min_lat}))"
+            )
+
+        # Construct a unique ID from the layer name and server URL
+        unique_id = f"geoserver_{geoserver_url}_{layer_name}"
+
+        # Construct a GetMap URL for the data_link
+        base_url = geoserver_url.split("?")[0]
+        params = {
+            "service": "WMS",
+            "request": "GetMap",
+            "layers": layer.name,
+            "format": "image/png",
+            "transparent": "true",
+            "width": 256,
+            "height": 256,
+            "bbox": "{bbox-epsg-3857}",
+            "srs": "EPSG:3857",
+        }
+        
+        data_link = f"{base_url}?{urlencode(params)}"
+
+        geo_object = GeoDataObject(
+            id=unique_id,
+            data_source_id=f"geoserver_{layer.name}",
+            data_type=DataType.RASTER,
+            data_origin=DataOrigin.TOOL.value,
+            data_source=wms.provider.contact.organization or "Unknown",
+            data_link=data_link,
+            name=layer.name,
+            title=layer.title,
+            description=layer.abstract,
+            llm_description=f"WMS layer: {layer.title} from GeoServer at {geoserver_url}",
+            score=0.9,
+            bounding_box=bounding_box,
+            layer_type="WMS",
+            properties={
+                "styles": layer.styles,
+                "srs": layer.crsOptions,
+                "keywords": layer.keywords,
+            },
+        )
+        layers.append(geo_object)
+    return layers
+
+
+def fetch_geoserver_capabilities(
+    backend: GeoServerBackend,
+) -> List[GeoDataObject]:
+    """Fetches and parses GetCapabilities from a single GeoServer backend."""
+    if not backend.enabled:
+        return []
+
+    try:
+        wms = WebMapService(
+            backend.url,
+            version="1.3.0",
+            username=backend.username,
+            password=backend.password,
+        )
+        return parse_wms_capabilities(wms, backend.url)
+    except Exception as e:
+        logger.error(f"Failed to get capabilities from {backend.url}: {e}")
+        return []
+
+
+@tool
+def get_custom_geoserver_data(
+    state: Annotated[GeoDataAgentState, InjectedState],
+    tool_call_id: Annotated[str, InjectedToolCallId],
+) -> Union[Dict[str, Any], ToolMessage]:
+    """
+    Use this tool to discover available data layers from pre-configured custom GeoServer instances.
+    This is useful for finding specific geospatial data that is not available through other tools
+    but might be hosted on a dedicated GeoServer.
+    The tool returns a list of available layers with their descriptions, which can then be used
+    for visualization or analysis.
+    """
+    options = state.get("options")
+    backends: List[GeoServerBackend] = []
+
+    if isinstance(options, SettingsSnapshot):
+        backends = options.geoserver_backends
+    elif isinstance(options, dict) and "geoserver_backends" in options:
+        geoserver_backends_dicts = options["geoserver_backends"]
+        if geoserver_backends_dicts:
+            backends = [GeoServerBackend(**b) for b in geoserver_backends_dicts]
+
+    if not backends:
+        return ToolMessage(
+            content="No GeoServer backends configured.", tool_call_id=tool_call_id
+        )
+
+    enabled_backends = [b for b in backends if b.enabled]
+    if not enabled_backends:
+        return ToolMessage(
+            content="All configured GeoServer backends are disabled.",
+            tool_call_id=tool_call_id,
+        )
+
+    all_layers = []
+    for backend in enabled_backends:
+        all_layers.extend(fetch_geoserver_capabilities(backend))
+
+    if not all_layers:
+        return ToolMessage(
+            content="No layers found on any of the configured GeoServer instances.",
+            tool_call_id=tool_call_id,
+        )
+
+    # Update the state with the new layers
+    current_layers = state.get("geodata_layers", [])
+    updated_layers = current_layers + all_layers
+    return {"geodata_layers": updated_layers}
+
+
+def main():
+    """Main function for manual testing."""
+    logging.basicConfig(level=logging.INFO)
+    logger.info("Starting manual test for custom_geoserver tool.")
+
+    # Example GeoServer backends
+    test_backends = [
+        GeoServerBackend(
+            url="https://io.apps.fao.org/geoserver/wms",
+            enabled=True,
+            username=None,
+            password=None,
+        ),
+        GeoServerBackend(
+            url="https://stable.demo.geonode.org/geoserver/wms",
+            enabled=True,
+            username=None,
+            password=None,
+        ),
+        GeoServerBackend(
+            url="http://invalid.url/geoserver/wms",
+            enabled=True,
+            username=None,
+            password=None,
+        ),
+    ]
+
+    all_geo_objects = []
+    for backend in test_backends:
+        all_geo_objects.extend(fetch_geoserver_capabilities(backend))
+
+    if all_geo_objects:
+        logger.info(f"Successfully fetched {len(all_geo_objects)} layers.")
+        # Print details of the first few layers as an example
+        for i, geo_obj in enumerate(all_geo_objects[:3]):
+            print(f"--- Layer {i+1} ---")
+            print(json.dumps(geo_obj.model_dump(), indent=2)[:2000])
+    else:
+        logger.warning("No layers were fetched from the test GeoServers.")
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/services/tools/geoserver/custom_geoserver.py
+++ b/backend/services/tools/geoserver/custom_geoserver.py
@@ -1,15 +1,18 @@
 """
 This tool is used to get data from a custom GeoServer instance.
 It uses the GetCapabilities endpoint of a GeoServer to get a list of layers
-and their descriptions.
+and their descriptions across WMS, WFS, WCS, and WMTS services.
 """
 
 import json
 import logging
 from typing import Any, Dict, List, Union
-from urllib.parse import urlencode
+from urllib.parse import urlencode, urljoin
 
+from owslib.wcs import WebCoverageService
+from owslib.wfs import WebFeatureService
 from owslib.wms import WebMapService
+from owslib.wmts import WebMapTileService
 from langchain_core.messages import ToolMessage
 from langchain_core.tools import tool
 from langchain_core.tools.base import InjectedToolCallId
@@ -23,11 +26,34 @@ from models.states import GeoDataAgentState
 logger = logging.getLogger(__name__)
 
 
+def merge_layers(
+    base_layers: Dict[str, GeoDataObject], new_layers: Dict[str, GeoDataObject]
+) -> Dict[str, GeoDataObject]:
+    """Merges new layer information into a base dictionary of layers."""
+    for layer_id, new_layer in new_layers.items():
+        if layer_id in base_layers:
+            # Merge service links
+            if new_layer.service_links:
+                if base_layers[layer_id].service_links is None:
+                    base_layers[layer_id].service_links = {}
+                base_layers[layer_id].service_links.update(new_layer.service_links)
+            # Optionally, update other fields if they are empty
+            if not base_layers[layer_id].description and new_layer.description:
+                base_layers[layer_id].description = new_layer.description
+            if not base_layers[layer_id].bounding_box and new_layer.bounding_box:
+                base_layers[layer_id].bounding_box = new_layer.bounding_box
+        else:
+            base_layers[layer_id] = new_layer
+    return base_layers
+
+
 def parse_wms_capabilities(
-    wms: WebMapService, geoserver_url: str
-) -> List[GeoDataObject]:
-    """Parses the WMS GetCapabilities response and returns a list of GeoDataObjects."""
-    layers: List[GeoDataObject] = []
+    wms, geoserver_url: str
+) -> Dict[str, GeoDataObject]:
+    """Parses WMS GetCapabilities and returns a dictionary of GeoDataObjects."""
+    layers: Dict[str, GeoDataObject] = {}
+    base_url = geoserver_url.split("?")[0]
+
     for layer_name, layer in wms.contents.items():
         bounding_box = None
         if layer.boundingBoxWGS84:
@@ -37,11 +63,6 @@ def parse_wms_capabilities(
                 f"{min_lon} {max_lat}, {min_lon} {min_lat}, {max_lon} {min_lat}))"
             )
 
-        # Construct a unique ID from the layer name and server URL
-        unique_id = f"geoserver_{geoserver_url}_{layer_name}"
-
-        # Construct a GetMap URL for the data_link
-        base_url = geoserver_url.split("?")[0]
         params = {
             "service": "WMS",
             "request": "GetMap",
@@ -53,51 +74,218 @@ def parse_wms_capabilities(
             "bbox": "{bbox-epsg-3857}",
             "srs": "EPSG:3857",
         }
-        
         data_link = f"{base_url}?{urlencode(params)}"
 
         geo_object = GeoDataObject(
-            id=unique_id,
+            id=layer.name,
             data_source_id=f"geoserver_{layer.name}",
             data_type=DataType.RASTER,
             data_origin=DataOrigin.TOOL.value,
             data_source=wms.provider.contact.organization or "Unknown",
             data_link=data_link,
             name=layer.name,
-            title=layer.title,
+            title=layer.title or layer.name,
             description=layer.abstract,
             llm_description=f"WMS layer: {layer.title} from GeoServer at {geoserver_url}",
             score=0.9,
             bounding_box=bounding_box,
             layer_type="WMS",
-            properties={
-                "styles": layer.styles,
-                "srs": layer.crsOptions,
-                "keywords": layer.keywords,
-            },
+            properties={"srs": layer.crsOptions, "keywords": layer.keywords},
+            service_links={"WMS": data_link},
         )
-        layers.append(geo_object)
+        layers[layer.name] = geo_object
     return layers
 
 
-def fetch_geoserver_capabilities(
-    backend: GeoServerBackend,
-) -> List[GeoDataObject]:
-    """Fetches and parses GetCapabilities from a single GeoServer backend."""
-    if not backend.enabled:
-        return []
+def parse_wfs_capabilities(
+    wfs, geoserver_url: str
+) -> Dict[str, GeoDataObject]:
+    """Parses WFS GetCapabilities and returns a dictionary of GeoDataObjects."""
+    layers: Dict[str, GeoDataObject] = {}
+    base_url = geoserver_url.split("?")[0]
 
+    for ft_name, ft in wfs.contents.items():
+        bounding_box = None
+        if ft.boundingBoxWGS84:
+            min_lon, min_lat, max_lon, max_lat = ft.boundingBoxWGS84
+            bounding_box = (
+                f"POLYGON(({max_lon} {min_lat}, {max_lon} {max_lat}, "
+                f"{min_lon} {max_lat}, {min_lon} {min_lat}, {max_lon} {min_lat}))"
+            )
+
+        params = {
+            "service": "WFS",
+            "version": "2.0.0",
+            "request": "GetFeature",
+            "typeName": ft.id,
+            "outputFormat": "application/json",
+        }
+        data_link = f"{base_url}?{urlencode(params)}"
+
+        geo_object = GeoDataObject(
+            id=ft.id,
+            data_source_id=f"geoserver_{ft.id}",
+            data_type=DataType.GEOJSON,
+            data_origin=DataOrigin.TOOL.value,
+            data_source=wfs.provider.name or "Unknown",
+            data_link=data_link,
+            name=ft.id,
+            title=ft.title or ft.id,
+            description=ft.abstract,
+            llm_description=f"WFS layer: {ft.title} from GeoServer at {geoserver_url}",
+            score=0.9,
+            bounding_box=bounding_box,
+            layer_type="WFS",
+            properties={"srs": ft.crsOptions, "keywords": ft.keywords},
+            service_links={"WFS": data_link},
+        )
+        layers[ft.id] = geo_object
+    return layers
+
+
+def parse_wcs_capabilities(
+    wcs, geoserver_url: str
+) -> Dict[str, GeoDataObject]:
+    """Parses WCS GetCapabilities and returns a dictionary of GeoDataObjects."""
+    layers: Dict[str, GeoDataObject] = {}
+    base_url = geoserver_url.split("?")[0]
+
+    for cov_id, cov in wcs.contents.items():
+        bounding_box = None
+        if cov.boundingBoxWGS84:
+            min_lon, min_lat, max_lon, max_lat = cov.boundingBoxWGS84
+            bounding_box = (
+                f"POLYGON(({max_lon} {min_lat}, {max_lon} {max_lat}, "
+                f"{min_lon} {max_lat}, {min_lon} {min_lat}, {max_lon} {min_lat}))"
+            )
+
+        params = {
+            "service": "WCS",
+            "version": "2.0.1",
+            "request": "GetCoverage",
+            "coverageId": cov.id,
+        }
+        data_link = f"{base_url}?{urlencode(params)}"
+
+        geo_object = GeoDataObject(
+            id=cov.id,
+            data_source_id=f"geoserver_{cov.id}",
+            data_type=DataType.RASTER,
+            data_origin=DataOrigin.TOOL.value,
+            data_source=wcs.provider.name or "Unknown",
+            data_link=data_link,
+            name=cov.id,
+            title=cov.title or cov.id,
+            description=cov.abstract,
+            llm_description=f"WCS layer: {cov.title} from GeoServer at {geoserver_url}",
+            score=0.9,
+            bounding_box=bounding_box,
+            layer_type="WCS",
+            properties={"supported_formats": cov.supportedFormats},
+            service_links={"WCS": data_link},
+        )
+        layers[cov.id] = geo_object
+    return layers
+
+
+def parse_wmts_capabilities(
+    wmts, geoserver_url: str
+) -> Dict[str, GeoDataObject]:
+    """Parses WMTS GetCapabilities and returns a dictionary of GeoDataObjects."""
+    layers: Dict[str, GeoDataObject] = {}
+
+    for layer_id, layer in wmts.contents.items():
+        bounding_box = None
+        if layer.boundingBoxWGS84:
+            min_lon, min_lat, max_lon, max_lat = layer.boundingBoxWGS84
+            bounding_box = (
+                f"POLYGON(({max_lon} {min_lat}, {max_lon} {max_lat}, "
+                f"{min_lon} {max_lat}, {min_lon} {min_lat}, {max_lon} {min_lat}))"
+            )
+
+        # WMTS link is a template
+        data_link = ""
+        if layer.tilematrixsetlinks:
+            # Get the first available tile matrix link template
+            first_link = list(layer.tilematrixsetlinks.values())[0]
+            data_link = first_link.template.format(
+                TileMatrix="{TileMatrix}", TileRow="{TileRow}", TileCol="{TileCol}"
+            )
+
+        geo_object = GeoDataObject(
+            id=layer.id,
+            data_source_id=f"geoserver_{layer.id}",
+            data_type=DataType.RASTER,
+            data_origin=DataOrigin.TOOL.value,
+            data_source=wmts.provider.name or "Unknown",
+            data_link=data_link,
+            name=layer.id,
+            title=layer.title or layer.id,
+            description=layer.abstract,
+            llm_description=f"WMTS layer: {layer.title} from GeoServer at {geoserver_url}",
+            score=0.9,
+            bounding_box=bounding_box,
+            layer_type="WMTS",
+            properties={"tile_matrix_sets": list(layer.tilematrixsetlinks.keys())},
+            service_links={"WMTS": data_link},
+        )
+        layers[layer.id] = geo_object
+    return layers
+
+
+def fetch_all_service_capabilities(
+    backend: GeoServerBackend,
+) -> Dict[str, GeoDataObject]:
+    """Fetches capabilities from all services and merges them."""
+    if not backend.enabled:
+        return {}
+
+    base_url = backend.url
+    username = backend.username
+    password = backend.password
+    all_layers: Dict[str, GeoDataObject] = {}
+
+    # WMS
+    wms_url = urljoin(base_url, "wms")
     try:
         wms = WebMapService(
-            backend.url,
-            version="1.3.0",
-            username=backend.username,
-            password=backend.password,
+            wms_url, version="1.3.0", username=username, password=password
         )
-        return parse_wms_capabilities(wms, backend.url)
+        wms_layers = parse_wms_capabilities(wms, wms_url)
+        all_layers = merge_layers(all_layers, wms_layers)
     except Exception as e:
-        logger.error(f"Failed to get capabilities from {backend.url}: {e}")
-        return []
+        logger.warning(f"Could not fetch WMS capabilities from {wms_url}: {e}")
+
+    # WFS
+    wfs_url = urljoin(base_url, "wfs")
+    try:
+        wfs = WebFeatureService(
+            wfs_url, version="2.0.0", username=username, password=password
+        )
+        wfs_layers = parse_wfs_capabilities(wfs, wfs_url)
+        all_layers = merge_layers(all_layers, wfs_layers)
+    except Exception as e:
+        logger.warning(f"Could not fetch WFS capabilities from {wfs_url}: {e}")
+
+    # WCS
+    wcs_url = urljoin(base_url, "wcs")
+    try:
+        wcs = WebCoverageService(wcs_url, version="2.0.1")
+        wcs_layers = parse_wcs_capabilities(wcs, wcs_url)
+        all_layers = merge_layers(all_layers, wcs_layers)
+    except Exception as e:
+        logger.warning(f"Could not fetch WCS capabilities from {wcs_url}: {e}")
+
+    # WMTS
+    wmts_url = urljoin(base_url, "gwc/service/wmts")
+    try:
+        wmts = WebMapTileService(wmts_url, username=username, password=password)
+        wmts_layers = parse_wmts_capabilities(wmts, wmts_url)
+        all_layers = merge_layers(all_layers, wmts_layers)
+    except Exception as e:
+        logger.warning(f"Could not fetch WMTS capabilities from {wmts_url}: {e}")
+
+    return all_layers
 
 
 @tool
@@ -134,11 +322,12 @@ def get_custom_geoserver_data(
             tool_call_id=tool_call_id,
         )
 
-    all_layers = []
+    all_layers_dict: Dict[str, GeoDataObject] = {}
     for backend in enabled_backends:
-        all_layers.extend(fetch_geoserver_capabilities(backend))
+        backend_layers = fetch_all_service_capabilities(backend)
+        all_layers_dict = merge_layers(all_layers_dict, backend_layers)
 
-    if not all_layers:
+    if not all_layers_dict:
         return ToolMessage(
             content="No layers found on any of the configured GeoServer instances.",
             tool_call_id=tool_call_id,
@@ -146,8 +335,12 @@ def get_custom_geoserver_data(
 
     # Update the state with the new layers
     current_layers = state.get("geodata_layers", [])
-    updated_layers = current_layers + all_layers
-    return {"geodata_layers": updated_layers}
+    # Create a dict of current layers for efficient lookup
+    current_layers_dict = {layer.id: layer for layer in current_layers}
+    
+    updated_layers_dict = merge_layers(current_layers_dict, all_layers_dict)
+    
+    return {"geodata_layers": list(updated_layers_dict.values())}
 
 
 def main():
@@ -158,35 +351,30 @@ def main():
     # Example GeoServer backends
     test_backends = [
         GeoServerBackend(
-            url="https://io.apps.fao.org/geoserver/wms",
+            url="https://io.apps.fao.org/geoserver/",
             enabled=True,
             username=None,
             password=None,
         ),
         GeoServerBackend(
-            url="https://stable.demo.geonode.org/geoserver/wms",
-            enabled=True,
-            username=None,
-            password=None,
-        ),
-        GeoServerBackend(
-            url="http://invalid.url/geoserver/wms",
+            url="https://stable.demo.geonode.org/geoserver/",
             enabled=True,
             username=None,
             password=None,
         ),
     ]
 
-    all_geo_objects = []
+    all_geo_objects_dict: Dict[str, GeoDataObject] = {}
     for backend in test_backends:
-        all_geo_objects.extend(fetch_geoserver_capabilities(backend))
+        backend_layers = fetch_all_service_capabilities(backend)
+        all_geo_objects_dict = merge_layers(all_geo_objects_dict, backend_layers)
 
-    if all_geo_objects:
-        logger.info(f"Successfully fetched {len(all_geo_objects)} layers.")
+    if all_geo_objects_dict:
+        logger.info(f"Successfully fetched {len(all_geo_objects_dict)} unique layers.")
         # Print details of the first few layers as an example
-        for i, geo_obj in enumerate(all_geo_objects[:3]):
+        for i, geo_obj in enumerate(list(all_geo_objects_dict.values())[:3]):
             print(f"--- Layer {i+1} ---")
-            print(json.dumps(geo_obj.model_dump(), indent=2)[:2000])
+            print(json.dumps(geo_obj.model_dump(), indent=2))
     else:
         logger.warning("No layers were fetched from the test GeoServers.")
 

--- a/backend/services/tools/geoserver/custom_geoserver.py
+++ b/backend/services/tools/geoserver/custom_geoserver.py
@@ -346,6 +346,14 @@ def parse_wmts_capabilities(
         except Exception:
             logger.debug("Unexpected WMTS link structure; skipping tile template extraction.")
 
+        # Post-process template for frontend safety: remove unsupported {style} placeholder
+        if data_link:
+            if "{style}" in data_link:
+                data_link = data_link.replace("{style}", "default")
+            # Prefer image/png over utfgrid JSON for rendering base tiles
+            if "application/json;type=utfgrid" in data_link:
+                data_link = data_link.replace("application/json;type=utfgrid", "image/png")
+
         geo_object = GeoDataObject(
             id=f"wmts_{layer.id}",
             data_source_id=f"geoserver_{layer.id}",

--- a/backend/tests/test_geoserver_backend_filters.py
+++ b/backend/tests/test_geoserver_backend_filters.py
@@ -1,0 +1,171 @@
+from typing import List
+
+import pytest
+
+from models.geodata import GeoDataObject, DataType, DataOrigin
+from models.settings_model import (
+    GeoServerBackend,
+    SettingsSnapshot,
+    SearchPortal,
+    ModelSettings,
+    ToolConfig,
+)
+from services.tools.geoserver.custom_geoserver import get_custom_geoserver_data
+from models.states import GeoDataAgentState
+
+
+class _StubBackendFetcher:
+    """Helper to monkeypatch fetch_all_service_capabilities returning canned layers."""
+    def __init__(self):
+        self.calls = []
+
+    def __call__(self, backend: GeoServerBackend, search_term=None):  # signature subset
+        self.calls.append(backend.url)
+        # generate two layers per backend with backend url embedded so assertions can check
+        layers: List[GeoDataObject] = []
+        for i in range(2):
+            layers.append(
+                GeoDataObject(
+                    id=f"wms_layer_{i}_{backend.url[-5:]}",
+                    data_source_id="geoserver_stub",
+                    data_type=DataType.RASTER,
+                    data_origin=DataOrigin.TOOL.value,
+                    data_source="Stub",
+                    data_link=f"{backend.url}wms?layer=layer{i}",
+                    name=f"layer_{i}",
+                    title=f"Layer {i}",
+                    description="",
+                    layer_type="WMS",
+                    properties={"srs": ["EPSG:4326"]},
+                )
+            )
+        return layers
+
+
+@pytest.fixture
+def settings_snapshot():
+    backends = [
+        GeoServerBackend(
+            url="https://example.com/geoserver/",
+            name="Primary",
+            description="First",
+            enabled=True,
+            username=None,
+            password=None,
+        ),
+        GeoServerBackend(
+            url="https://alt.example.com/geoserver/",
+            name="Secondary",
+            description="Second",
+            enabled=True,
+            username=None,
+            password=None,
+        ),
+    ]
+    return SettingsSnapshot(
+        search_portals=[SearchPortal(url="https://portal.example.com", enabled=True)],
+        geoserver_backends=backends,
+        model_settings=ModelSettings(
+            model_provider="local",
+            model_name="none",
+            max_tokens=1,
+            system_prompt="",
+        ),
+        tools=[
+            ToolConfig(
+                name="get_custom_geoserver_data",
+                enabled=True,
+                prompt_override="",
+            )
+        ],
+    )
+
+
+def _base_state(snapshot: SettingsSnapshot) -> GeoDataAgentState:
+    return {
+        "options": snapshot,
+        "geodata_layers": [],
+        "messages": [],
+        "results_title": "",
+        "geodata_last_results": [],
+        "geodata_results": [],
+        "remaining_steps": 0,
+    }
+
+
+def test_backend_name_filter(monkeypatch, settings_snapshot):
+    stub = _StubBackendFetcher()
+    from services.tools.geoserver import custom_geoserver as cg
+    monkeypatch.setattr(cg, "fetch_all_service_capabilities", stub)
+
+    state = _base_state(settings_snapshot)
+    result = get_custom_geoserver_data.invoke({
+        "state": state,
+        "tool_call_id": "test_call",
+        "backend_name": "Primary",
+    })
+    # unwrap Command update
+    if hasattr(result, "update"):
+        update = result.update
+    else:
+        update = result
+    layers = update.get("geodata_results", [])
+    assert len(layers) == 2  # only one backend queried
+    assert stub.calls == ["https://example.com/geoserver/"]
+    # metadata annotation
+    for lyr in layers:
+        assert lyr.properties.get("_backend_url") == "https://example.com/geoserver/"
+        assert lyr.properties.get("_backend_name") == "Primary"
+        assert lyr.properties.get("_backend_description") == "First"
+
+
+def test_backend_url_filter(monkeypatch, settings_snapshot):
+    stub = _StubBackendFetcher()
+    from services.tools.geoserver import custom_geoserver as cg
+    monkeypatch.setattr(cg, "fetch_all_service_capabilities", stub)
+
+    state = _base_state(settings_snapshot)
+    result = get_custom_geoserver_data.invoke({
+        "state": state,
+        "tool_call_id": "test_call",
+        "backend_url": "https://alt.example.com/geoserver/",
+    })
+    if hasattr(result, "update"):
+        update = result.update
+    else:
+        update = result
+    layers = update.get("geodata_results", [])
+    assert len(layers) == 2
+    assert stub.calls == ["https://alt.example.com/geoserver/"]
+    for lyr in layers:
+        assert lyr.properties.get("_backend_url") == "https://alt.example.com/geoserver/"
+        assert lyr.properties.get("_backend_name") == "Secondary"
+        assert lyr.properties.get("_backend_description") == "Second"
+
+
+def test_no_filter_queries_all(monkeypatch, settings_snapshot):
+    stub = _StubBackendFetcher()
+    from services.tools.geoserver import custom_geoserver as cg
+    monkeypatch.setattr(cg, "fetch_all_service_capabilities", stub)
+
+    state = _base_state(settings_snapshot)
+    result = get_custom_geoserver_data.invoke({
+        "state": state,
+        "tool_call_id": "test_call",
+    })
+    if hasattr(result, "update"):
+        update = result.update
+    else:
+        update = result
+    layers = update.get("geodata_results", [])
+    assert len(layers) == 4  # two backends * two layers each
+    assert set(stub.calls) == {
+        "https://example.com/geoserver/",
+        "https://alt.example.com/geoserver/",
+    }
+    # ensure each layer carries metadata
+    urls = {layer.properties.get("_backend_url") for layer in layers}
+    assert urls == {
+        "https://example.com/geoserver/",
+        "https://alt.example.com/geoserver/",
+    }

--- a/backend/tests/test_geoserver_sanitization.py
+++ b/backend/tests/test_geoserver_sanitization.py
@@ -1,0 +1,32 @@
+import types
+from services.tools.geoserver.custom_geoserver import _sanitize_crs_list, _sanitize_properties
+
+
+def test_sanitize_crs_list_basic():
+    class FakeCrs:
+        def __init__(self, code, proj4=None):
+            self.code = code
+            self.proj4 = proj4
+    crs_items = [
+        FakeCrs("EPSG:4326"),
+        "EPSG:3857",
+        FakeCrs(None, proj4="+proj=longlat +datum=WGS84"),
+    ]
+    out = _sanitize_crs_list(crs_items)
+    assert "EPSG:4326" in out
+    assert "EPSG:3857" in out
+    # Fallback to proj4 str conversion
+    assert any("+proj=longlat" in x for x in out)
+
+
+def test_sanitize_properties_nested():
+    nested = {
+        "a": {"b": {"c": 1}},
+        "set": {1, 2, 3},
+        "obj": types.SimpleNamespace(x=5),
+    }
+    sanitized = _sanitize_properties(nested)
+    assert isinstance(sanitized["a"], dict)
+    assert sanitized["a"]["b"]["c"] == 1
+    assert sorted(sanitized["set"]) == [1, 2, 3]
+    assert sanitized["obj"].startswith("namespace(")

--- a/backend/tests/test_geoserver_tools.py
+++ b/backend/tests/test_geoserver_tools.py
@@ -2,191 +2,299 @@ import pytest
 from unittest.mock import MagicMock, patch
 
 from models.geodata import GeoDataObject, DataType, DataOrigin
-from models.settings_model import GeoServerBackend, SettingsSnapshot, ModelSettings
+from models.settings_model import (
+    GeoServerBackend,
+    ModelSettings,
+    SearchPortal,
+    SettingsSnapshot,
+    ToolConfig,
+)
 from models.states import GeoDataAgentState
 from services.tools.geoserver.custom_geoserver import (
-    fetch_geoserver_capabilities,
+    fetch_all_service_capabilities,
     get_custom_geoserver_data,
+    merge_layers,
     parse_wms_capabilities,
+    parse_wfs_capabilities,
+    parse_wcs_capabilities,
+    parse_wmts_capabilities,
 )
 
-# Mock data for a WMS capabilities response
+# Mock URLs
+MOCK_GEOSERVER_URL = "http://mockgeoserver.com/"
 MOCK_WMS_URL = "http://mockgeoserver.com/wms"
+MOCK_WFS_URL = "http://mockgeoserver.com/wfs"
+MOCK_WCS_URL = "http://mockgeoserver.com/wcs"
+MOCK_WMTS_URL = "http://mockgeoserver.com/gwc/service/wmts"
 
 
 @pytest.fixture
 def mock_wms_service():
-    """Fixture to create a mock WebMapService object."""
+    """Fixture for a mock WMS service."""
     wms = MagicMock()
-    wms.provider.contact.organization = "Mock Organization"
-    wms.provider.url = MOCK_WMS_URL
-    wms.contents = {
-        "layer1": MagicMock(
-            name="layer1",
-            title="Mock Layer 1",
-            abstract="This is the first mock layer.",
-            boundingBoxWGS84=(-180, -90, 180, 90),
-            styles={},
-            crsOptions=[],
-            keywords=[],
-        ),
-        "layer2": MagicMock(
-            name="layer2",
-            title="Mock Layer 2",
-            abstract="This is the second mock layer.",
-            boundingBoxWGS84=None,  # Test case with no bounding box
-            styles={},
-            crsOptions=[],
-            keywords=[],
-        ),
-    }
+    wms.provider.contact.organization = "Mock WMS Org"
+    layer = MagicMock(
+        title="Mock Layer 1",
+        abstract="Abstract for layer 1.",
+        boundingBoxWGS84=(-10, -10, 10, 10),
+        crsOptions=[],
+        keywords=[],
+    )
+    layer.name = "workspace:layer1"  # Set the name attribute directly
+    wms.contents = {"workspace:layer1": layer}
     return wms
 
 
-def test_parse_wms_capabilities(mock_wms_service):
-    """Test the parsing of WMS capabilities into GeoDataObjects."""
-    layers = parse_wms_capabilities(mock_wms_service, MOCK_WMS_URL)
-
-    assert len(layers) == 2
-    layer1 = layers[0]
-    assert isinstance(layer1, GeoDataObject)
-    assert layer1.name == "layer1"
-    assert layer1.title == "Mock Layer 1"
-    assert layer1.data_type == DataType.RASTER
-    assert layer1.data_origin == DataOrigin.TOOL.value
-    assert layer1.bounding_box is not None
-    assert "POLYGON" in layer1.bounding_box
-
-    layer2 = layers[1]
-    assert layer2.name == "layer2"
-    assert layer2.bounding_box is None
-
-
-def test_fetch_geoserver_capabilities_disabled():
-    """Test that disabled backends are skipped."""
-    backend = GeoServerBackend(
-        url=MOCK_WMS_URL, enabled=False, username=None, password=None
-    )
-    result = fetch_geoserver_capabilities(backend)
-    assert result == []
-
-
-@patch("services.tools.geoserver.custom_geoserver.WebMapService")
-def test_fetch_geoserver_capabilities_success(mock_wms_constructor, mock_wms_service):
-    """Test successful fetching and parsing of capabilities."""
-    mock_wms_constructor.return_value = mock_wms_service
-
-    backend = GeoServerBackend(
-        url=MOCK_WMS_URL, enabled=True, username="user", password="password"
-    )
-    layers = fetch_geoserver_capabilities(backend)
-
-    assert len(layers) == 2
-    assert layers[0].name == "layer1"
-    mock_wms_constructor.assert_called_once_with(
-        backend.url,
-        version="1.3.0",
-        username=backend.username,
-        password=backend.password,
-    )
-
-
-@patch("services.tools.geoserver.custom_geoserver.WebMapService")
-def test_fetch_geoserver_capabilities_failure(mock_wms_constructor):
-    """Test handling of exceptions during fetching."""
-    mock_wms_constructor.side_effect = Exception("Connection failed")
-
-    backend = GeoServerBackend(
-        url=MOCK_WMS_URL, enabled=True, username=None, password=None
-    )
-    result = fetch_geoserver_capabilities(backend)
-    assert result == []
-
-
-def test_get_custom_geoserver_data_no_options():
-    """Test tool behavior when no options are in the state."""
-    state = {"options": None}
-    tool_call_id = "test_id"
-    result = get_custom_geoserver_data.invoke(
-        {"state": state, "tool_call_id": tool_call_id}
-    )
-    assert "No GeoServer backends configured" in result.content
-
-
-def test_get_custom_geoserver_data_empty_backends():
-    """Test tool behavior with empty backends list."""
-    state = {
-        "options": SettingsSnapshot(
-            geoserver_backends=[],
-            search_portals=[],
-            model_settings=ModelSettings(
-                model_provider="test",
-                model_name="test",
-                max_tokens=1,
-                system_prompt="",
-            ),
-            tools=[],
+@pytest.fixture
+def mock_wfs_service():
+    """Fixture for a mock WFS service."""
+    wfs = MagicMock()
+    wfs.provider.name = "Mock WFS Org"
+    wfs.contents = {
+        "workspace:layer1": MagicMock(
+            id="workspace:layer1",
+            title="Mock Feature 1",
+            abstract="Abstract for feature 1.",
+            boundingBoxWGS84=(-10, -10, 10, 10),
+            crsOptions=[],
+            keywords=[],
         )
     }
-    tool_call_id = "test_id"
-    result = get_custom_geoserver_data.invoke(
-        {"state": state, "tool_call_id": tool_call_id}
+    return wfs
+
+
+@pytest.fixture
+def mock_wcs_service():
+    """Fixture for a mock WCS service."""
+    wcs = MagicMock()
+    wcs.provider.name = "Mock WCS Org"
+    wcs.contents = {
+        "workspace:layer1": MagicMock(
+            id="workspace:layer1",
+            title="Mock Coverage 1",
+            abstract="Abstract for coverage 1.",
+            boundingBoxWGS84=(-10, -10, 10, 10),
+            supportedFormats=[],
+        )
+    }
+    return wcs
+
+
+@pytest.fixture
+def mock_wmts_service():
+    """Fixture for a mock WMTS service."""
+    wmts = MagicMock()
+    wmts.provider.name = "Mock WMTS Org"
+    tile_matrix_link = MagicMock()
+    tile_matrix_link.template = "http://mock/tile/{TileMatrix}/{TileRow}/{TileCol}"
+    wmts.contents = {
+        "workspace:layer1": MagicMock(
+            id="workspace:layer1",
+            title="Mock Tile 1",
+            abstract="Abstract for tile 1.",
+            boundingBoxWGS84=(-10, -10, 10, 10),
+            tilematrixsetlinks={"default": tile_matrix_link},
+        )
+    }
+    return wmts
+
+
+@pytest.fixture
+def mock_settings_snapshot() -> SettingsSnapshot:
+    """Fixture for a valid SettingsSnapshot."""
+    return SettingsSnapshot(
+        search_portals=[SearchPortal(url="http://mockportal.com", enabled=True)],
+        geoserver_backends=[
+            GeoServerBackend(
+                url=MOCK_GEOSERVER_URL, enabled=True, username=None, password=None
+            )
+        ],
+        model_settings=ModelSettings(
+            model_provider="mock",
+            model_name="mock-model",
+            max_tokens=100,
+            system_prompt="You are a helpful assistant.",
+        ),
+        tools=[
+            ToolConfig(name="mock_tool", enabled=True, prompt_override="")
+        ],
     )
-    assert "No GeoServer backends configured" in result.content
 
 
-@patch("services.tools.geoserver.custom_geoserver.fetch_geoserver_capabilities")
-def test_get_custom_geoserver_data_success(mock_fetch):
-    """Test the complete tool flow with mocked fetching."""
-    # Mock fetch to return a list with one GeoDataObject
-    mock_layer = GeoDataObject(
-        id="1",
-        data_source_id="ds1",
+def test_parse_wms_capabilities(mock_wms_service):
+    """Test parsing of WMS capabilities."""
+    layers = parse_wms_capabilities(mock_wms_service, MOCK_WMS_URL)
+    assert "workspace:layer1" in layers
+    layer = layers["workspace:layer1"]
+    assert layer.layer_type == "WMS"
+    assert layer.service_links is not None
+    assert "WMS" in layer.service_links
+
+
+def test_parse_wfs_capabilities(mock_wfs_service):
+    """Test parsing of WFS capabilities."""
+    layers = parse_wfs_capabilities(mock_wfs_service, MOCK_WFS_URL)
+    assert "workspace:layer1" in layers
+    layer = layers["workspace:layer1"]
+    assert layer.layer_type == "WFS"
+    assert layer.service_links is not None
+    assert "WFS" in layer.service_links
+
+
+def test_parse_wcs_capabilities(mock_wcs_service):
+    """Test parsing of WCS capabilities."""
+    layers = parse_wcs_capabilities(mock_wcs_service, MOCK_WCS_URL)
+    assert "workspace:layer1" in layers
+    layer = layers["workspace:layer1"]
+    assert layer.layer_type == "WCS"
+    assert layer.service_links is not None
+    assert "WCS" in layer.service_links
+
+
+def test_parse_wmts_capabilities(mock_wmts_service):
+    """Test parsing of WMTS capabilities."""
+    layers = parse_wmts_capabilities(mock_wmts_service, MOCK_WMTS_URL)
+    assert "workspace:layer1" in layers
+    layer = layers["workspace:layer1"]
+    assert layer.layer_type == "WMTS"
+    assert layer.service_links is not None
+    assert "WMTS" in layer.service_links
+
+
+def test_merge_layers():
+    """Test merging of layer dictionaries."""
+    base_layer = GeoDataObject(
+        id="layer1",
+        data_source_id="test_source_1",
+        data_link="http://wms",
+        name="Layer 1",
+        title="Layer 1",
+        service_links={"WMS": "http://wms"},
+        description="Base",
         data_type=DataType.RASTER,
         data_origin=DataOrigin.TOOL.value,
         data_source="test",
-        data_link="http://test.com",
-        name="test_layer",
     )
-    mock_fetch.return_value = [mock_layer]
+    new_layer = GeoDataObject(
+        id="layer1",
+        data_source_id="test_source_1",
+        data_link="http://wfs",
+        name="Layer 1",
+        title="Layer 1",
+        service_links={"WFS": "http://wfs"},
+        description="New",
+        data_type=DataType.RASTER,
+        data_origin=DataOrigin.TOOL.value,
+        data_source="test",
+    )
+    merged = merge_layers({"layer1": base_layer}, {"layer1": new_layer})
+    assert "layer1" in merged
+    assert len(merged) == 1
+    assert merged["layer1"].service_links is not None
+    assert "WMS" in merged["layer1"].service_links
+    assert "WFS" in merged["layer1"].service_links
+    assert merged["layer1"].description == "Base"  # Description should not be overwritten
 
-    backends = [
-        GeoServerBackend(url=MOCK_WMS_URL, enabled=True, username=None, password=None),
-        GeoServerBackend(
-            url="http://another.com", enabled=False, username=None, password=None
-        ),  # Should be ignored
-    ]
-    options = SettingsSnapshot(
-        geoserver_backends=backends,
-        search_portals=[],
-        model_settings=ModelSettings(
-            model_provider="test", model_name="test", max_tokens=1, system_prompt=""
-        ),
-        tools=[],
+
+@patch("services.tools.geoserver.custom_geoserver.WebMapService")
+@patch("services.tools.geoserver.custom_geoserver.WebFeatureService")
+@patch("services.tools.geoserver.custom_geoserver.WebCoverageService")
+@patch("services.tools.geoserver.custom_geoserver.WebMapTileService")
+def test_fetch_all_service_capabilities(
+    mock_wmts_constructor, mock_wcs_constructor, mock_wfs_constructor, mock_wms_constructor,
+    mock_wms_service, mock_wfs_service, mock_wcs_service, mock_wmts_service
+):
+    """Test fetching from all services and merging the results."""
+    mock_wms_constructor.return_value = mock_wms_service
+    mock_wfs_constructor.return_value = mock_wfs_service
+    mock_wcs_constructor.return_value = mock_wcs_service
+    mock_wmts_constructor.return_value = mock_wmts_service
+
+    backend = GeoServerBackend(
+        url=MOCK_GEOSERVER_URL, enabled=True, username="user", password="pw"
     )
-    initial_layers = [
-        GeoDataObject(
-            id="0",
-            name="initial",
-            data_source_id="ds0",
-            data_type=DataType.RASTER,
-            data_origin=DataOrigin.TOOL.value,
-            data_source="test",
-            data_link="http://test.com",
-        )
-    ]
-    state = GeoDataAgentState(
-        messages=[], options=options, geodata_layers=initial_layers
+    layers = fetch_all_service_capabilities(backend)
+
+    assert len(layers) == 1
+    assert "workspace:layer1" in layers
+    layer = layers["workspace:layer1"]
+    assert layer.service_links is not None
+    assert "WMS" in layer.service_links
+    assert "WFS" in layer.service_links
+    assert "WCS" in layer.service_links
+    assert "WMTS" in layer.service_links
+
+
+@patch("services.tools.geoserver.custom_geoserver.fetch_all_service_capabilities")
+def test_get_custom_geoserver_data(mock_fetch, mock_settings_snapshot):
+    """Test the main tool entry point."""
+    mock_layer = GeoDataObject(
+        id="layer1",
+        name="Test Layer",
+        title="Test Layer",
+        data_type=DataType.RASTER,
+        data_origin=DataOrigin.TOOL.value,
+        data_source="test",
+        data_source_id="test_source_1",
+        data_link="http://mock.link",
     )
-    tool_call_id = "test_id"
+    mock_fetch.return_value = {"layer1": mock_layer}
+
+    initial_state: GeoDataAgentState = {
+        "options": mock_settings_snapshot,
+        "geodata_layers": [],
+        "messages": [],
+        "results_title": "",
+        "geodata_last_results": [],
+        "geodata_results": [],
+        "remaining_steps": 0,
+    }
+    tool_call_id = "test_tool_call"
 
     result = get_custom_geoserver_data.invoke(
-        {"state": state, "tool_call_id": tool_call_id}
+        {"state": initial_state, "tool_call_id": tool_call_id}
     )
 
-    assert mock_fetch.call_count == 1
     assert "geodata_layers" in result
-    updated_layers = result["geodata_layers"]
-    assert len(updated_layers) == 2
-    assert updated_layers[0].name == "initial"
-    assert updated_layers[1].name == "test_layer"
+    layers = result["geodata_layers"]
+    assert len(layers) == 1
+    assert layers[0].id == "layer1"
+    mock_fetch.assert_called_once()
+
+
+def test_get_custom_geoserver_data_no_backends(mock_settings_snapshot):
+    """Test tool behavior when no backends are configured."""
+    mock_settings_snapshot.geoserver_backends = []
+    initial_state: GeoDataAgentState = {
+        "options": mock_settings_snapshot,
+        "geodata_layers": [],
+        "messages": [],
+        "results_title": "",
+        "geodata_last_results": [],
+        "geodata_results": [],
+        "remaining_steps": 0,
+    }
+    tool_call_id = "test_tool_call"
+    result = get_custom_geoserver_data.invoke(
+        {"state": initial_state, "tool_call_id": tool_call_id}
+    )
+    assert "No GeoServer backends configured" in result.content
+
+
+def test_get_custom_geoserver_data_no_enabled_backends(mock_settings_snapshot):
+    """Test tool behavior when all backends are disabled."""
+    mock_settings_snapshot.geoserver_backends[0].enabled = False
+    initial_state: GeoDataAgentState = {
+        "options": mock_settings_snapshot,
+        "geodata_layers": [],
+        "messages": [],
+        "results_title": "",
+        "geodata_last_results": [],
+        "geodata_results": [],
+        "remaining_steps": 0,
+    }
+    tool_call_id = "test_tool_call"
+    result = get_custom_geoserver_data.invoke(
+        {"state": initial_state, "tool_call_id": tool_call_id}
+    )
+    assert "All configured GeoServer backends are disabled" in result.content

--- a/backend/tests/test_geoserver_tools.py
+++ b/backend/tests/test_geoserver_tools.py
@@ -235,14 +235,17 @@ def test_get_custom_geoserver_data(mock_fetch, initial_agent_state):
     assert not isinstance(result, ToolMessage)
     # support tools returning a Command(update=...) or a plain dict
     if isinstance(result, Command):
-        result_dict = result.update
+        result_dict = result.update or {}
     else:
         result_dict = result
 
-    assert "geodata_layers" in result_dict
-    layers = result_dict["geodata_layers"]
+    # Tool should NOT modify geodata_layers; results go to geodata_results
+    assert "geodata_results" in result_dict
+    layers = result_dict["geodata_results"]
     assert len(layers) == 1
     assert layers[0].id == "wms_layer1"
+    # geodata_layers remains the original empty list
+    assert result_dict.get("geodata_layers") == []
     mock_fetch.assert_called_once_with(
         initial_agent_state["options"].geoserver_backends[0], search_term=None
     )
@@ -278,13 +281,15 @@ def test_get_custom_geoserver_data_with_params(mock_fetch, initial_agent_state):
     assert not isinstance(result, ToolMessage)
     # support tools returning a Command(update=...) or a plain dict
     if isinstance(result, Command):
-        result_dict = result.update
+        result_dict = result.update or {}
     else:
         result_dict = result
 
-    assert "geodata_layers" in result_dict
-    layers = result_dict["geodata_layers"]
+    assert "geodata_results" in result_dict
+    layers = result_dict["geodata_results"]
     assert len(layers) == 3
+    # geodata_layers unchanged
+    assert result_dict.get("geodata_layers") == []
     mock_fetch.assert_called_once_with(
         initial_agent_state["options"].geoserver_backends[0], search_term="Test"
     )

--- a/backend/tests/test_geoserver_tools.py
+++ b/backend/tests/test_geoserver_tools.py
@@ -244,8 +244,8 @@ def test_get_custom_geoserver_data(mock_fetch, initial_agent_state):
     layers = result_dict["geodata_results"]
     assert len(layers) == 1
     assert layers[0].id == "wms_layer1"
-    # geodata_layers remains the original empty list
-    assert result_dict.get("geodata_layers") == []
+    # geodata_layers not included / unchanged (should not be set by tool)
+    assert "geodata_layers" not in result_dict or result_dict.get("geodata_layers") == []
     mock_fetch.assert_called_once_with(
         initial_agent_state["options"].geoserver_backends[0], search_term=None
     )
@@ -288,8 +288,8 @@ def test_get_custom_geoserver_data_with_params(mock_fetch, initial_agent_state):
     assert "geodata_results" in result_dict
     layers = result_dict["geodata_results"]
     assert len(layers) == 3
-    # geodata_layers unchanged
-    assert result_dict.get("geodata_layers") == []
+    # geodata_layers unchanged / not provided in update
+    assert "geodata_layers" not in result_dict or result_dict.get("geodata_layers") == []
     mock_fetch.assert_called_once_with(
         initial_agent_state["options"].geoserver_backends[0], search_term="Test"
     )

--- a/backend/tests/test_geoserver_tools.py
+++ b/backend/tests/test_geoserver_tools.py
@@ -1,0 +1,192 @@
+import pytest
+from unittest.mock import MagicMock, patch
+
+from models.geodata import GeoDataObject, DataType, DataOrigin
+from models.settings_model import GeoServerBackend, SettingsSnapshot, ModelSettings
+from models.states import GeoDataAgentState
+from services.tools.geoserver.custom_geoserver import (
+    fetch_geoserver_capabilities,
+    get_custom_geoserver_data,
+    parse_wms_capabilities,
+)
+
+# Mock data for a WMS capabilities response
+MOCK_WMS_URL = "http://mockgeoserver.com/wms"
+
+
+@pytest.fixture
+def mock_wms_service():
+    """Fixture to create a mock WebMapService object."""
+    wms = MagicMock()
+    wms.provider.contact.organization = "Mock Organization"
+    wms.provider.url = MOCK_WMS_URL
+    wms.contents = {
+        "layer1": MagicMock(
+            name="layer1",
+            title="Mock Layer 1",
+            abstract="This is the first mock layer.",
+            boundingBoxWGS84=(-180, -90, 180, 90),
+            styles={},
+            crsOptions=[],
+            keywords=[],
+        ),
+        "layer2": MagicMock(
+            name="layer2",
+            title="Mock Layer 2",
+            abstract="This is the second mock layer.",
+            boundingBoxWGS84=None,  # Test case with no bounding box
+            styles={},
+            crsOptions=[],
+            keywords=[],
+        ),
+    }
+    return wms
+
+
+def test_parse_wms_capabilities(mock_wms_service):
+    """Test the parsing of WMS capabilities into GeoDataObjects."""
+    layers = parse_wms_capabilities(mock_wms_service, MOCK_WMS_URL)
+
+    assert len(layers) == 2
+    layer1 = layers[0]
+    assert isinstance(layer1, GeoDataObject)
+    assert layer1.name == "layer1"
+    assert layer1.title == "Mock Layer 1"
+    assert layer1.data_type == DataType.RASTER
+    assert layer1.data_origin == DataOrigin.TOOL.value
+    assert layer1.bounding_box is not None
+    assert "POLYGON" in layer1.bounding_box
+
+    layer2 = layers[1]
+    assert layer2.name == "layer2"
+    assert layer2.bounding_box is None
+
+
+def test_fetch_geoserver_capabilities_disabled():
+    """Test that disabled backends are skipped."""
+    backend = GeoServerBackend(
+        url=MOCK_WMS_URL, enabled=False, username=None, password=None
+    )
+    result = fetch_geoserver_capabilities(backend)
+    assert result == []
+
+
+@patch("services.tools.geoserver.custom_geoserver.WebMapService")
+def test_fetch_geoserver_capabilities_success(mock_wms_constructor, mock_wms_service):
+    """Test successful fetching and parsing of capabilities."""
+    mock_wms_constructor.return_value = mock_wms_service
+
+    backend = GeoServerBackend(
+        url=MOCK_WMS_URL, enabled=True, username="user", password="password"
+    )
+    layers = fetch_geoserver_capabilities(backend)
+
+    assert len(layers) == 2
+    assert layers[0].name == "layer1"
+    mock_wms_constructor.assert_called_once_with(
+        backend.url,
+        version="1.3.0",
+        username=backend.username,
+        password=backend.password,
+    )
+
+
+@patch("services.tools.geoserver.custom_geoserver.WebMapService")
+def test_fetch_geoserver_capabilities_failure(mock_wms_constructor):
+    """Test handling of exceptions during fetching."""
+    mock_wms_constructor.side_effect = Exception("Connection failed")
+
+    backend = GeoServerBackend(
+        url=MOCK_WMS_URL, enabled=True, username=None, password=None
+    )
+    result = fetch_geoserver_capabilities(backend)
+    assert result == []
+
+
+def test_get_custom_geoserver_data_no_options():
+    """Test tool behavior when no options are in the state."""
+    state = {"options": None}
+    tool_call_id = "test_id"
+    result = get_custom_geoserver_data.invoke(
+        {"state": state, "tool_call_id": tool_call_id}
+    )
+    assert "No GeoServer backends configured" in result.content
+
+
+def test_get_custom_geoserver_data_empty_backends():
+    """Test tool behavior with empty backends list."""
+    state = {
+        "options": SettingsSnapshot(
+            geoserver_backends=[],
+            search_portals=[],
+            model_settings=ModelSettings(
+                model_provider="test",
+                model_name="test",
+                max_tokens=1,
+                system_prompt="",
+            ),
+            tools=[],
+        )
+    }
+    tool_call_id = "test_id"
+    result = get_custom_geoserver_data.invoke(
+        {"state": state, "tool_call_id": tool_call_id}
+    )
+    assert "No GeoServer backends configured" in result.content
+
+
+@patch("services.tools.geoserver.custom_geoserver.fetch_geoserver_capabilities")
+def test_get_custom_geoserver_data_success(mock_fetch):
+    """Test the complete tool flow with mocked fetching."""
+    # Mock fetch to return a list with one GeoDataObject
+    mock_layer = GeoDataObject(
+        id="1",
+        data_source_id="ds1",
+        data_type=DataType.RASTER,
+        data_origin=DataOrigin.TOOL.value,
+        data_source="test",
+        data_link="http://test.com",
+        name="test_layer",
+    )
+    mock_fetch.return_value = [mock_layer]
+
+    backends = [
+        GeoServerBackend(url=MOCK_WMS_URL, enabled=True, username=None, password=None),
+        GeoServerBackend(
+            url="http://another.com", enabled=False, username=None, password=None
+        ),  # Should be ignored
+    ]
+    options = SettingsSnapshot(
+        geoserver_backends=backends,
+        search_portals=[],
+        model_settings=ModelSettings(
+            model_provider="test", model_name="test", max_tokens=1, system_prompt=""
+        ),
+        tools=[],
+    )
+    initial_layers = [
+        GeoDataObject(
+            id="0",
+            name="initial",
+            data_source_id="ds0",
+            data_type=DataType.RASTER,
+            data_origin=DataOrigin.TOOL.value,
+            data_source="test",
+            data_link="http://test.com",
+        )
+    ]
+    state = GeoDataAgentState(
+        messages=[], options=options, geodata_layers=initial_layers
+    )
+    tool_call_id = "test_id"
+
+    result = get_custom_geoserver_data.invoke(
+        {"state": state, "tool_call_id": tool_call_id}
+    )
+
+    assert mock_fetch.call_count == 1
+    assert "geodata_layers" in result
+    updated_layers = result["geodata_layers"]
+    assert len(updated_layers) == 2
+    assert updated_layers[0].name == "initial"
+    assert updated_layers[1].name == "test_layer"

--- a/backend/tests/test_geoserver_tools.py
+++ b/backend/tests/test_geoserver_tools.py
@@ -20,6 +20,7 @@ from services.tools.geoserver.custom_geoserver import (
     parse_wms_capabilities,
     parse_wmts_capabilities,
 )
+from langgraph.types import Command
 
 # Mock URLs
 MOCK_GEOSERVER_URL = "http://mockgeoserver.com/"
@@ -232,8 +233,14 @@ def test_get_custom_geoserver_data(mock_fetch, initial_agent_state):
     result = _get_custom_geoserver_data(state=initial_agent_state, tool_call_id=tool_call_id)
 
     assert not isinstance(result, ToolMessage)
-    assert "geodata_layers" in result
-    layers = result["geodata_layers"]
+    # support tools returning a Command(update=...) or a plain dict
+    if isinstance(result, Command):
+        result_dict = result.update
+    else:
+        result_dict = result
+
+    assert "geodata_layers" in result_dict
+    layers = result_dict["geodata_layers"]
     assert len(layers) == 1
     assert layers[0].id == "wms_layer1"
     mock_fetch.assert_called_once_with(
@@ -269,8 +276,14 @@ def test_get_custom_geoserver_data_with_params(mock_fetch, initial_agent_state):
     )
 
     assert not isinstance(result, ToolMessage)
-    assert "geodata_layers" in result
-    layers = result["geodata_layers"]
+    # support tools returning a Command(update=...) or a plain dict
+    if isinstance(result, Command):
+        result_dict = result.update
+    else:
+        result_dict = result
+
+    assert "geodata_layers" in result_dict
+    layers = result_dict["geodata_layers"]
     assert len(layers) == 3
     mock_fetch.assert_called_once_with(
         initial_agent_state["options"].geoserver_backends[0], search_term="Test"

--- a/backend/tests/test_geoserver_tools.py
+++ b/backend/tests/test_geoserver_tools.py
@@ -1,6 +1,8 @@
 import pytest
 from unittest.mock import MagicMock, patch
 
+from langchain_core.messages import ToolMessage
+
 from models.geodata import GeoDataObject, DataType, DataOrigin
 from models.settings_model import (
     GeoServerBackend,
@@ -11,12 +13,11 @@ from models.settings_model import (
 )
 from models.states import GeoDataAgentState
 from services.tools.geoserver.custom_geoserver import (
+    _get_custom_geoserver_data,
     fetch_all_service_capabilities,
-    get_custom_geoserver_data,
-    merge_layers,
-    parse_wms_capabilities,
-    parse_wfs_capabilities,
     parse_wcs_capabilities,
+    parse_wfs_capabilities,
+    parse_wms_capabilities,
     parse_wmts_capabilities,
 )
 
@@ -33,15 +34,23 @@ def mock_wms_service():
     """Fixture for a mock WMS service."""
     wms = MagicMock()
     wms.provider.contact.organization = "Mock WMS Org"
-    layer = MagicMock(
+    layer1 = MagicMock(
         title="Mock Layer 1",
         abstract="Abstract for layer 1.",
         boundingBoxWGS84=(-10, -10, 10, 10),
         crsOptions=[],
         keywords=[],
     )
-    layer.name = "workspace:layer1"  # Set the name attribute directly
-    wms.contents = {"workspace:layer1": layer}
+    layer1.name = "workspace:layer1"
+    layer2 = MagicMock(
+        title="Another Layer",
+        abstract="Different abstract.",
+        boundingBoxWGS84=(-20, -20, 20, 20),
+        crsOptions=[],
+        keywords=[],
+    )
+    layer2.name = "workspace:layer2"
+    wms.contents = {"workspace:layer1": layer1, "workspace:layer2": layer2}
     return wms
 
 
@@ -115,85 +124,61 @@ def mock_settings_snapshot() -> SettingsSnapshot:
             max_tokens=100,
             system_prompt="You are a helpful assistant.",
         ),
-        tools=[
-            ToolConfig(name="mock_tool", enabled=True, prompt_override="")
-        ],
+        tools=[ToolConfig(name="mock_tool", enabled=True, prompt_override="")],
     )
+
+
+@pytest.fixture
+def initial_agent_state(mock_settings_snapshot) -> GeoDataAgentState:
+    """Fixture for a valid initial agent state."""
+    return {
+        "options": mock_settings_snapshot,
+        "geodata_layers": [],
+        "messages": [],
+        "results_title": "",
+        "geodata_last_results": [],
+        "geodata_results": [],
+        "remaining_steps": 0,
+    }
 
 
 def test_parse_wms_capabilities(mock_wms_service):
     """Test parsing of WMS capabilities."""
     layers = parse_wms_capabilities(mock_wms_service, MOCK_WMS_URL)
-    assert "workspace:layer1" in layers
-    layer = layers["workspace:layer1"]
-    assert layer.layer_type == "WMS"
-    assert layer.service_links is not None
-    assert "WMS" in layer.service_links
+    assert len(layers) == 2
+    assert layers[0].layer_type == "WMS"
+    assert layers[0].id == "wms_workspace:layer1"
+
+
+def test_parse_wms_capabilities_with_search(mock_wms_service):
+    """Test parsing of WMS capabilities with a search term."""
+    layers = parse_wms_capabilities(mock_wms_service, MOCK_WMS_URL, search_term="Another")
+    assert len(layers) == 1
+    assert layers[0].title == "Another Layer"
 
 
 def test_parse_wfs_capabilities(mock_wfs_service):
     """Test parsing of WFS capabilities."""
     layers = parse_wfs_capabilities(mock_wfs_service, MOCK_WFS_URL)
-    assert "workspace:layer1" in layers
-    layer = layers["workspace:layer1"]
-    assert layer.layer_type == "WFS"
-    assert layer.service_links is not None
-    assert "WFS" in layer.service_links
+    assert len(layers) == 1
+    assert layers[0].layer_type == "WFS"
+    assert layers[0].id == "wfs_workspace:layer1"
 
 
 def test_parse_wcs_capabilities(mock_wcs_service):
     """Test parsing of WCS capabilities."""
     layers = parse_wcs_capabilities(mock_wcs_service, MOCK_WCS_URL)
-    assert "workspace:layer1" in layers
-    layer = layers["workspace:layer1"]
-    assert layer.layer_type == "WCS"
-    assert layer.service_links is not None
-    assert "WCS" in layer.service_links
+    assert len(layers) == 1
+    assert layers[0].layer_type == "WCS"
+    assert layers[0].id == "wcs_workspace:layer1"
 
 
 def test_parse_wmts_capabilities(mock_wmts_service):
     """Test parsing of WMTS capabilities."""
     layers = parse_wmts_capabilities(mock_wmts_service, MOCK_WMTS_URL)
-    assert "workspace:layer1" in layers
-    layer = layers["workspace:layer1"]
-    assert layer.layer_type == "WMTS"
-    assert layer.service_links is not None
-    assert "WMTS" in layer.service_links
-
-
-def test_merge_layers():
-    """Test merging of layer dictionaries."""
-    base_layer = GeoDataObject(
-        id="layer1",
-        data_source_id="test_source_1",
-        data_link="http://wms",
-        name="Layer 1",
-        title="Layer 1",
-        service_links={"WMS": "http://wms"},
-        description="Base",
-        data_type=DataType.RASTER,
-        data_origin=DataOrigin.TOOL.value,
-        data_source="test",
-    )
-    new_layer = GeoDataObject(
-        id="layer1",
-        data_source_id="test_source_1",
-        data_link="http://wfs",
-        name="Layer 1",
-        title="Layer 1",
-        service_links={"WFS": "http://wfs"},
-        description="New",
-        data_type=DataType.RASTER,
-        data_origin=DataOrigin.TOOL.value,
-        data_source="test",
-    )
-    merged = merge_layers({"layer1": base_layer}, {"layer1": new_layer})
-    assert "layer1" in merged
-    assert len(merged) == 1
-    assert merged["layer1"].service_links is not None
-    assert "WMS" in merged["layer1"].service_links
-    assert "WFS" in merged["layer1"].service_links
-    assert merged["layer1"].description == "Base"  # Description should not be overwritten
+    assert len(layers) == 1
+    assert layers[0].layer_type == "WMTS"
+    assert layers[0].id == "wmts_workspace:layer1"
 
 
 @patch("services.tools.geoserver.custom_geoserver.WebMapService")
@@ -201,10 +186,16 @@ def test_merge_layers():
 @patch("services.tools.geoserver.custom_geoserver.WebCoverageService")
 @patch("services.tools.geoserver.custom_geoserver.WebMapTileService")
 def test_fetch_all_service_capabilities(
-    mock_wmts_constructor, mock_wcs_constructor, mock_wfs_constructor, mock_wms_constructor,
-    mock_wms_service, mock_wfs_service, mock_wcs_service, mock_wmts_service
+    mock_wmts_constructor,
+    mock_wcs_constructor,
+    mock_wfs_constructor,
+    mock_wms_constructor,
+    mock_wms_service,
+    mock_wfs_service,
+    mock_wcs_service,
+    mock_wmts_service,
 ):
-    """Test fetching from all services and merging the results."""
+    """Test fetching from all services and getting a flat list."""
     mock_wms_constructor.return_value = mock_wms_service
     mock_wfs_constructor.return_value = mock_wfs_service
     mock_wcs_constructor.return_value = mock_wcs_service
@@ -215,21 +206,18 @@ def test_fetch_all_service_capabilities(
     )
     layers = fetch_all_service_capabilities(backend)
 
-    assert len(layers) == 1
-    assert "workspace:layer1" in layers
-    layer = layers["workspace:layer1"]
-    assert layer.service_links is not None
-    assert "WMS" in layer.service_links
-    assert "WFS" in layer.service_links
-    assert "WCS" in layer.service_links
-    assert "WMTS" in layer.service_links
+    assert len(layers) == 5  # 2 from WMS, 1 from each of the others
+    assert any(layer.id == "wms_workspace:layer1" for layer in layers)
+    assert any(layer.id == "wfs_workspace:layer1" for layer in layers)
+    assert any(layer.id == "wcs_workspace:layer1" for layer in layers)
+    assert any(layer.id == "wmts_workspace:layer1" for layer in layers)
 
 
 @patch("services.tools.geoserver.custom_geoserver.fetch_all_service_capabilities")
-def test_get_custom_geoserver_data(mock_fetch, mock_settings_snapshot):
+def test_get_custom_geoserver_data(mock_fetch, initial_agent_state):
     """Test the main tool entry point."""
     mock_layer = GeoDataObject(
-        id="layer1",
+        id="wms_layer1",
         name="Test Layer",
         title="Test Layer",
         data_type=DataType.RASTER,
@@ -238,63 +226,74 @@ def test_get_custom_geoserver_data(mock_fetch, mock_settings_snapshot):
         data_source_id="test_source_1",
         data_link="http://mock.link",
     )
-    mock_fetch.return_value = {"layer1": mock_layer}
-
-    initial_state: GeoDataAgentState = {
-        "options": mock_settings_snapshot,
-        "geodata_layers": [],
-        "messages": [],
-        "results_title": "",
-        "geodata_last_results": [],
-        "geodata_results": [],
-        "remaining_steps": 0,
-    }
+    mock_fetch.return_value = [mock_layer]
     tool_call_id = "test_tool_call"
 
-    result = get_custom_geoserver_data.invoke(
-        {"state": initial_state, "tool_call_id": tool_call_id}
-    )
+    result = _get_custom_geoserver_data(state=initial_agent_state, tool_call_id=tool_call_id)
 
+    assert not isinstance(result, ToolMessage)
     assert "geodata_layers" in result
     layers = result["geodata_layers"]
     assert len(layers) == 1
-    assert layers[0].id == "layer1"
-    mock_fetch.assert_called_once()
-
-
-def test_get_custom_geoserver_data_no_backends(mock_settings_snapshot):
-    """Test tool behavior when no backends are configured."""
-    mock_settings_snapshot.geoserver_backends = []
-    initial_state: GeoDataAgentState = {
-        "options": mock_settings_snapshot,
-        "geodata_layers": [],
-        "messages": [],
-        "results_title": "",
-        "geodata_last_results": [],
-        "geodata_results": [],
-        "remaining_steps": 0,
-    }
-    tool_call_id = "test_tool_call"
-    result = get_custom_geoserver_data.invoke(
-        {"state": initial_state, "tool_call_id": tool_call_id}
+    assert layers[0].id == "wms_layer1"
+    mock_fetch.assert_called_once_with(
+        initial_agent_state["options"].geoserver_backends[0], search_term=None
     )
+
+
+@patch("services.tools.geoserver.custom_geoserver.fetch_all_service_capabilities")
+def test_get_custom_geoserver_data_with_params(mock_fetch, initial_agent_state):
+    """Test the tool with search and max_results parameters."""
+    mock_layers = [
+        GeoDataObject(
+            id=f"wms_layer{i}",
+            name=f"Test Layer {i}",
+            title=f"Test Layer {i}",
+            data_type=DataType.RASTER,
+            data_origin=DataOrigin.TOOL.value,
+            data_source="test",
+            data_source_id=f"test_source_{i}",
+            data_link="http://mock.link",
+        )
+        for i in range(5)
+    ]
+    mock_fetch.return_value = mock_layers
+    tool_call_id = "test_tool_call"
+
+    # The tool itself handles the max_results logic, so the mock can return all.
+    result = _get_custom_geoserver_data(
+        state=initial_agent_state,
+        tool_call_id=tool_call_id,
+        search_term="Test",
+        max_results=3,
+    )
+
+    assert not isinstance(result, ToolMessage)
+    assert "geodata_layers" in result
+    layers = result["geodata_layers"]
+    assert len(layers) == 3
+    mock_fetch.assert_called_once_with(
+        initial_agent_state["options"].geoserver_backends[0], search_term="Test"
+    )
+
+
+def test_get_custom_geoserver_data_no_backends(initial_agent_state):
+    """Test tool behavior when no backends are configured."""
+    initial_agent_state["options"].geoserver_backends = []
+    tool_call_id = "test_tool_call"
+
+    result = _get_custom_geoserver_data(state=initial_agent_state, tool_call_id=tool_call_id)
+
+    assert isinstance(result, ToolMessage)
     assert "No GeoServer backends configured" in result.content
 
 
-def test_get_custom_geoserver_data_no_enabled_backends(mock_settings_snapshot):
+def test_get_custom_geoserver_data_no_enabled_backends(initial_agent_state):
     """Test tool behavior when all backends are disabled."""
-    mock_settings_snapshot.geoserver_backends[0].enabled = False
-    initial_state: GeoDataAgentState = {
-        "options": mock_settings_snapshot,
-        "geodata_layers": [],
-        "messages": [],
-        "results_title": "",
-        "geodata_last_results": [],
-        "geodata_results": [],
-        "remaining_steps": 0,
-    }
+    initial_agent_state["options"].geoserver_backends[0].enabled = False
     tool_call_id = "test_tool_call"
-    result = get_custom_geoserver_data.invoke(
-        {"state": initial_state, "tool_call_id": tool_call_id}
-    )
+
+    result = _get_custom_geoserver_data(state=initial_agent_state, tool_call_id=tool_call_id)
+
+    assert isinstance(result, ToolMessage)
     assert "All configured GeoServer backends are disabled" in result.content

--- a/backend/tests/test_tool_configurator.py
+++ b/backend/tests/test_tool_configurator.py
@@ -1,0 +1,219 @@
+import asyncio
+
+from models.settings_model import ToolConfig
+from utility.tool_configurator import create_configured_tools
+from langchain_core.tools import BaseTool
+from pydantic import ConfigDict
+
+
+class FakeTool(BaseTool):
+    name: str = "fake_tool"
+    description: str = "orig"
+    sync_calls: list = []  # for tracking
+    async_calls: list = []  # for tracking
+    model_config = ConfigDict(extra="allow")
+
+    def __init__(self, description: str = "orig"):
+        super().__init__()
+        # ensure per-instance lists
+        object.__setattr__(self, "description", description)
+        object.__setattr__(self, "sync_calls", [])
+        object.__setattr__(self, "async_calls", [])
+
+    def _run(self, *args, **kwargs):  # type: ignore[override]
+        self.sync_calls.append((args, kwargs))
+        return {"result": "sync", "args": args, "kwargs": kwargs}
+
+    async def _arun(self, *args, **kwargs):  # type: ignore[override]
+        self.async_calls.append((args, kwargs))
+        return {"result": "async", "args": args, "kwargs": kwargs}
+
+
+def make_tool_config(name: str, enabled: bool = True, prompt_override: str = "") -> ToolConfig:
+    return ToolConfig(name=name, enabled=enabled, prompt_override=prompt_override)
+
+
+def test_disabled_tools_are_filtered_out():
+    t1 = FakeTool()
+    t2 = FakeTool()
+
+    tools: dict[str, BaseTool] = {"one": t1, "two": t2}  # type: ignore[assignment]
+    cfgs = [make_tool_config("one", enabled=True), make_tool_config("two", enabled=False)]
+
+    configured = create_configured_tools(tools, cfgs)
+
+    assert "one" in configured
+    assert "two" not in configured
+
+
+def test_prompt_override_and_sync_wrapper_merges_extras(monkeypatch):
+    tool_name = "sync_tool"
+    fake = FakeTool(description="original description")
+
+    tools: dict[str, BaseTool] = {tool_name: fake}  # type: ignore[assignment]
+    cfg = make_tool_config(tool_name, enabled=True, prompt_override="Custom prompt")
+
+    # Monkeypatch the ToolConfig.model_dump to include extra fields that should be injected
+    def fake_model_dump(self):
+        return {
+            "name": tool_name,
+            "enabled": True,
+            "prompt_override": "Custom prompt",
+            "system_prompt": "SYS",
+            "tool_prompt": "TP",
+        }
+
+    # Patch at the class level so pydantic doesn't forbid setting instance attributes
+    monkeypatch.setattr(ToolConfig, "model_dump", fake_model_dump, raising=False)
+
+    configured = create_configured_tools(tools, [cfg])
+    assert tool_name in configured
+
+    wrapped = configured[tool_name]
+
+    # Description should be overridden
+    assert getattr(wrapped, "description") == "Custom prompt"
+
+    # Call the wrapped sync run; extras should NOT be merged because _run has no matching params
+    result = wrapped._run(1, foo="bar")
+    assert result["result"] == "sync"
+    # original fake recorded call should include merged keys
+    assert fake.sync_calls, "original _run was not called"
+    args, kwargs = fake.sync_calls[-1]
+    assert kwargs.get("foo") == "bar"
+    # extras not injected because parameters absent
+    assert "system_prompt" not in kwargs
+    assert "tool_prompt" not in kwargs
+
+
+def test_extras_injected_when_params_exist(monkeypatch):
+    class ParamTool(BaseTool):
+        name: str = "param_tool"
+        description: str = "param"
+        model_config = ConfigDict(extra="allow")
+        calls: list = []  # tracking
+
+        def __init__(self):  # type: ignore[override]
+            super().__init__()
+            object.__setattr__(self, "calls", [])
+
+        def _run(self, system_prompt=None, tool_prompt=None, **kwargs):  # type: ignore[override]
+            self.calls.append((system_prompt, tool_prompt, kwargs))
+            return {"system_prompt": system_prompt, "tool_prompt": tool_prompt, "kwargs": kwargs}
+
+    tool = ParamTool()
+    tools: dict[str, BaseTool] = {tool.name: tool}  # type: ignore[assignment]
+    cfg = make_tool_config(tool.name, enabled=True, prompt_override="Override")
+
+    def fake_model_dump(self):
+        return {
+            "name": tool.name,
+            "enabled": True,
+            "prompt_override": "Override",
+            "system_prompt": "SYS",
+            "tool_prompt": "TP",
+        }
+
+    monkeypatch.setattr(ToolConfig, "model_dump", fake_model_dump, raising=False)
+    configured = create_configured_tools(tools, [cfg])
+    configured[tool.name]._run()
+    system_prompt, tool_prompt, kwargs = tool.calls[-1]
+    assert system_prompt == "SYS"
+    assert tool_prompt == "TP"
+
+
+def test_async_wrapper_merges_extras(monkeypatch):
+    class AsyncParamTool(BaseTool):
+        name: str = "async_param_tool"
+        description: str = "async param"
+        model_config = ConfigDict(extra="allow")
+        calls: list = []
+
+        def __init__(self):
+            super().__init__()
+            object.__setattr__(self, "calls", [])
+
+        async def _arun(self, extra_flag=False, **kwargs):  # type: ignore[override]
+            self.calls.append((extra_flag, kwargs))
+            return {"result": "async", "extra_flag": extra_flag, "kwargs": kwargs}
+
+        def _run(self, *args, **kwargs):  # type: ignore[override]
+            # Not used in this test
+            return {"result": "sync"}
+
+    tool = AsyncParamTool()
+    tools: dict[str, BaseTool] = {tool.name: tool}  # type: ignore[assignment]
+    cfg = make_tool_config(tool.name, enabled=True, prompt_override="Async Param Prompt")
+
+    def fake_model_dump(self):
+        return {
+            "name": tool.name,
+            "enabled": True,
+            "prompt_override": "Async Param Prompt",
+            "extra_flag": True,
+        }
+
+    monkeypatch.setattr(ToolConfig, "model_dump", fake_model_dump, raising=False)
+    configured = create_configured_tools(tools, [cfg])
+    coro = configured[tool.name]._arun()
+    result = asyncio.run(coro)
+    assert result["extra_flag"] is True
+    assert tool.calls[-1][0] is True
+
+
+def test_signature_preserved(monkeypatch):
+    """Ensure the original _run signature is unchanged after configuration."""
+    import inspect
+
+    tool_name = "sig_tool"
+    fake = FakeTool()
+    tools: dict[str, BaseTool] = {tool_name: fake}  # type: ignore[assignment]
+    cfg = make_tool_config(tool_name, enabled=True)
+
+    original_sig = inspect.signature(fake._run)
+    configured = create_configured_tools(tools, [cfg])
+    wrapped = configured[tool_name]
+    new_sig = inspect.signature(wrapped._run)
+    assert original_sig == new_sig
+
+
+def test_idempotent_configuration(monkeypatch):
+    """Calling create_configured_tools twice shouldn't wrap repeatedly or duplicate extras."""
+    tool_name = "idempotent_tool"
+    fake = FakeTool()
+    tools: dict[str, BaseTool] = {tool_name: fake}  # type: ignore[assignment]
+    cfg = make_tool_config(tool_name, enabled=True)
+
+    configured1 = create_configured_tools(tools, [cfg])
+    configured2 = create_configured_tools(configured1, [cfg])
+    # Run tool
+    configured2[tool_name]._run(foo=1)
+    # Only one call recorded
+    assert len(fake.sync_calls) == 1
+
+
+def test_missing_arun_graceful(monkeypatch):
+    """If a tool lacks _arun, configuration should not fail and _run still works."""
+
+    class NoAsyncTool(BaseTool):
+        name: str = "no_async_tool"
+        description: str = "na"
+        calls: list = []  # tracking
+        model_config = ConfigDict(extra="allow")
+
+        def __init__(self):
+            super().__init__()
+            object.__setattr__(self, "calls", [])
+
+        def _run(self, *args, **kwargs):  # type: ignore[override]
+            self.calls.append((args, kwargs))
+            return {"ok": True}
+
+    tool_name = "no_async"
+    t = NoAsyncTool()
+    tools: dict[str, BaseTool] = {tool_name: t}  # type: ignore[assignment]
+    cfg = make_tool_config(tool_name, enabled=True, prompt_override="New desc")
+    configured = create_configured_tools(tools, [cfg])
+    configured[tool_name]._run(a=1)
+    assert t.calls, "_run not invoked"  # ensure still callable
+    assert configured[tool_name].description == "New desc"

--- a/backend/tests/test_wmts_sanitization.py
+++ b/backend/tests/test_wmts_sanitization.py
@@ -1,0 +1,37 @@
+from services.tools.geoserver.custom_geoserver import parse_wmts_capabilities
+
+
+class _MockLayer:
+    def __init__(self, lid):
+        self.id = lid
+        self.title = lid
+        self.abstract = ""
+        self.boundingBoxWGS84 = (-1, -1, 1, 1)
+        self.resourceURLs = [
+            {
+                "template": (
+                    "https://example.com/wmts/rest/workspace:layer/{style}/"
+                    "{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}?format="
+                    "application/json;type=utfgrid"
+                )
+            }
+        ]
+        self.tilematrixsetlinks = {}
+
+class _MockProvider:
+    name = "Mock WMTS Org"
+
+class _MockWMTS:
+    def __init__(self):
+        self.contents = {"workspace:layer": _MockLayer("workspace:layer")}
+        self.provider = _MockProvider()
+
+
+def test_wmts_template_sanitized():
+    wmts = _MockWMTS()
+    layers = parse_wmts_capabilities(wmts, "http://example.com/gwc/service/wmts")
+    assert len(layers) == 1
+    link = layers[0].data_link
+    assert "{style}" not in link
+    assert "application/json;type=utfgrid" not in link
+    assert "image/png" in link

--- a/backend/utility/tool_configurator.py
+++ b/backend/utility/tool_configurator.py
@@ -1,67 +1,131 @@
-from copy import copy
+"""Tool configurator that preserves original BaseTool instances.
+
+Strategy:
+  * Return only enabled tools.
+  * Apply prompt_override by setting the tool.description (does not alter schema).
+  * (Future) Extras: merge static config values into runtime kwargs without
+    changing the public signature to keep LangChain's binder happy.
+  * Avoid wrapping with new callables to prevent docstring/signature mismatch
+    errors like: "Arg state in docstring not found in function signature.".
+"""
+
 from typing import Dict, Any, List
 from models.settings_model import ToolConfig
-
-from langchain_core.runnables import RunnableConfig
-from langchain_core.callbacks import AsyncCallbackManagerForToolRun, CallbackManagerForToolRun
 from langchain_core.tools import BaseTool
+import inspect
+import functools
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def _attach_extras(tool: BaseTool, extras: Dict[str, Any]):
+    """Patch the tool's _run and _arun to inject extras as default kwargs.
+
+    We do NOT modify the signature; we only add missing kwargs at runtime.
+    Only keys that are parameters of the underlying function are applied to
+    avoid unexpected argument errors.
+    """
+
+    if not extras:
+        return
+
+    # Underlying callable for sync
+    run_attr = getattr(tool, "_run", None)
+    if run_attr and callable(run_attr):
+        try:
+            sig = inspect.signature(run_attr)
+            valid_names = set(sig.parameters.keys())
+        except Exception:
+            valid_names = set()
+
+        @functools.wraps(run_attr)
+        def patched_run(*args, **kwargs):
+            for k, v in extras.items():
+                if k in valid_names and k not in kwargs:
+                    kwargs[k] = v
+            return run_attr(*args, **kwargs)
+
+        tool._run = patched_run  # type: ignore
+
+    # Async variant
+    arun_attr = getattr(tool, "_arun", None)
+    if arun_attr and callable(arun_attr):
+        try:
+            asig = inspect.signature(arun_attr)
+            aval = set(asig.parameters.keys())
+        except Exception:
+            aval = set()
+
+        try:
+            is_coroutine = inspect.iscoroutinefunction(arun_attr)
+        except Exception:
+            is_coroutine = False
+
+        if is_coroutine:
+            @functools.wraps(arun_attr)
+            async def patched_arun_async(*args, **kwargs):
+                for k, v in extras.items():
+                    if k in aval and k not in kwargs:
+                        kwargs[k] = v
+                return await arun_attr(*args, **kwargs)
+
+            try:
+                tool._arun = patched_arun_async  # type: ignore
+            except Exception:
+                logger.debug(
+                    "Could not patch coroutine _arun for tool %s", getattr(tool, 'name', 'unknown')
+                )
+        else:  # Graceful: treat as sync fallback executed in async context
+            @functools.wraps(arun_attr)
+            async def patched_arun_sync_wrapper(*args, **kwargs):  # type: ignore
+                for k, v in extras.items():
+                    if k in aval and k not in kwargs:
+                        kwargs[k] = v
+                return arun_attr(*args, **kwargs)
+
+            try:
+                tool._arun = patched_arun_sync_wrapper  # type: ignore
+            except Exception:
+                logger.debug(
+                    "Could not patch sync-as-async _arun for tool %s", getattr(tool, 'name', 'unknown')
+                )
+
+    # Keep a reference for debugging
+    setattr(tool, "config_extras", extras)
 
 
 def create_configured_tools(
     tool_functions: Dict[str, BaseTool], tool_settings: List[ToolConfig]
 ) -> Dict[str, BaseTool]:
-    configured: Dict[str, BaseTool] = {}
+    if not tool_settings:
+        # Nothing overridden; return originals
+        return tool_functions
+
     settings_map = {cfg.name: cfg for cfg in tool_settings}
+    configured: Dict[str, BaseTool] = {}
 
     for name, tool in tool_functions.items():
         cfg = settings_map.get(name)
         if not cfg or not cfg.enabled:
             continue
 
-        prompt_override = cfg.prompt_override
+        # Apply prompt override
+        if cfg.prompt_override:
+            try:
+                tool.description = cfg.prompt_override  # type: ignore
+            except Exception:
+                logger.debug("Failed to set description for tool %s", name)
+
+        # Extract extras (future extension fields beyond current schema)
         extras = {
             k: v
             for k, v in cfg.model_dump().items()
-            if k not in ("name", "enabled", "prompt_override")
+            if k not in ("name", "enabled", "prompt_override") and v is not None
         }
+        if extras:
+            _attach_extras(tool, extras)
 
-        new_tool = copy(tool)  # avoid mutating the original
-
-        # Override the tool description with the prompt_override
-        if prompt_override:
-            new_tool.description = prompt_override
-
-        def make_wrapped_sync(original_run):
-            def wrapped_sync(
-                *args: Any,
-                config: RunnableConfig,
-                run_manager: CallbackManagerForToolRun = None,
-                **kwargs: Any,
-            ) -> Any:
-                local_kwargs = {**kwargs, **extras}
-                return original_run(*args, config=config, run_manager=run_manager, **local_kwargs)
-
-            return wrapped_sync
-
-        def make_wrapped_async(original_arun):
-            async def wrapped_async(
-                *args: Any,
-                config: RunnableConfig,
-                run_manager: AsyncCallbackManagerForToolRun = None,
-                **kwargs: Any,
-            ) -> Any:
-                local_kwargs = {**kwargs, **extras}
-                return await original_arun(
-                    *args, config=config, run_manager=run_manager, **local_kwargs
-                )
-
-            return wrapped_async
-
-        setattr(new_tool, "_run", make_wrapped_sync(getattr(tool, "_run")))
-
-        if hasattr(tool, "_arun"):
-            setattr(new_tool, "_arun", make_wrapped_async(getattr(tool, "_arun")))
-
-        configured[name] = new_tool
+        configured[name] = tool
 
     return configured

--- a/frontend/app/settings/page.tsx
+++ b/frontend/app/settings/page.tsx
@@ -55,7 +55,7 @@ export default function SettingsPage() {
     const setSettings = useInitializedSettingsStore((s) => s.setSettings)
     // local state
     const [newPortal, setNewPortal] = useState('')
-    const [newBackend, setNewBackend] = useState<Omit<GeoServerBackend, 'enabled'>>({ url: '', username: '', password: '' })
+    const [newBackend, setNewBackend] = useState<Omit<GeoServerBackend, 'enabled'>>({ url: '', name: '', description: '', username: '', password: '' })
     const [newToolName, setNewToolName] = useState('')
 
 
@@ -265,6 +265,18 @@ export default function SettingsPage() {
                             className="border rounded p-2 w-full"
                         />
                         <input
+                            value={newBackend.name}
+                            onChange={(e) => setNewBackend({ ...newBackend, name: e.target.value })}
+                            placeholder="Name (optional)"
+                            className="border rounded p-2 w-full"
+                        />
+                        <textarea
+                            value={newBackend.description}
+                            onChange={(e) => setNewBackend({ ...newBackend, description: e.target.value })}
+                            placeholder="Description (optional)"
+                            className="border rounded p-2 w-full h-20"
+                        />
+                        <input
                             value={newBackend.username}
                             onChange={(e) => setNewBackend({ ...newBackend, username: e.target.value })}
                             placeholder="Username (optional)"
@@ -278,7 +290,7 @@ export default function SettingsPage() {
                             className="border rounded p-2 w-full"
                         />
                         <button
-                            onClick={() => { addBackend(newBackend); setNewBackend({ url: '', username: '', password: '' }) }}
+                            onClick={() => { addBackend(newBackend); setNewBackend({ url: '', name: '', description: '', username: '', password: '' }) }}
                             className="bg-blue-600 text-white px-4 py-2 rounded"
                         >
                             Add Backend
@@ -295,7 +307,8 @@ export default function SettingsPage() {
                                         className="form-checkbox h-5 w-5 text-green-600"
                                     />
                                     <div>
-                                        <p className={`${b.enabled ? 'text-gray-900' : 'text-gray-400'}`}><strong>URL:</strong> {b.url}</p>
+                                        <p className={`${b.enabled ? 'text-gray-900' : 'text-gray-400'}`}><strong>{b.name || 'URL'}:</strong> {b.url}</p>
+                                        {b.description && <p className={`${b.enabled ? 'text-gray-700' : 'text-gray-400'} text-sm`}>{b.description}</p>}
                                         {b.username && <p className={`${b.enabled ? 'text-gray-900' : 'text-gray-400'}`}><strong>Username:</strong> {b.username}</p>}
                                     </div>
                                 </label>

--- a/frontend/app/stores/settingsStore.ts
+++ b/frontend/app/stores/settingsStore.ts
@@ -2,6 +2,8 @@ import { create } from 'zustand'
 
 export interface GeoServerBackend {
     url: string
+    name?: string
+    description?: string
     username?: string
     password?: string
     enabled: boolean


### PR DESCRIPTION
# Pull Request
Adds custom Geoserver Integration
## Description
Allows user to add their own geoserver in the frontend settings page.
User can provide, the geoserver base url, possible user and password for authentication, and optionally a name and description for the agent to use.

The agent can use a new custom geoserver tool, to find layers within this geoserver using a search parameter, optional bounding box and a geoserver name or url in case multiple geoserver backends are configured,

In addition to the the Geoserver tool, the tool configurator was simplified and improved.

And more test cases were added to simplify development and stability in the future.

## Related Issue
<!-- Link to the related issue if applicable -->
Fixes #
* WMTS layer representation not working correctly
* Tool Configuration crashing on some optional parameters and types

## Type of Change
<!-- Mark with an `x` all the boxes that apply -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
<!-- Mark with an `x` all the boxes that apply -->
- [X] My code follows the code style of this project
- [X] I have tested my changes locally
- [X] I have updated the documentation accordingly
- [X] My changes don't break existing functionality
- [X] I have added tests that prove my fix/feature works
