### PR TITLE
Add Playwright frontend tests and CI integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,10 @@
 name: CI
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
-    paths:
-      - 'backend/**'
 
 jobs:
   test:
@@ -65,5 +66,31 @@ jobs:
         run: |
           poetry run flake8 .
           poetry run black --check .
+
+  frontend-tests:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps
+
+      - name: Run frontend end-to-end tests
+        run: npm run test:e2e
+        env:
+          NEXT_TELEMETRY_DISABLED: '1'
+          CI: 'true'
 
       

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -12,6 +12,7 @@
 
 # testing
 /coverage
+test-results/
 
 # next.js
 /.next/

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.1.0",
       "dependencies": {
         "@ai-sdk/react": "^1.1.19",
-        "@tailwindcss/oxide-linux-x64-gnu": "^4.1.13",
         "@tmcw/togeojson": "^7.1.0",
         "@types/geojson": "^7946.0.16",
         "@types/leaflet": "^1.9.16",
@@ -32,6 +31,7 @@
         "zustand": "^5.0.8"
       },
       "devDependencies": {
+        "@playwright/test": "^1.55.0",
         "@tailwindcss/postcss": "^4",
         "@tailwindcss/typography": "^0.5.16",
         "@types/node": "^20",
@@ -850,6 +850,22 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.0.tgz",
+      "integrity": "sha512-04IXzPwHrW69XusN/SIdDdKZBzMfOT9UNT/YiJit/xpy2VuAoB8NHc8Aplb96zsWDddLnbkPL3TsmrS04ZU2xQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@react-leaflet/core": {
@@ -1966,6 +1982,21 @@
       "funding": {
         "type": "patreon",
         "url": "https://github.com/sponsors/rawify"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/geojson-vt": {
@@ -3445,6 +3476,38 @@
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "license": "ISC"
+    },
+    "node_modules/playwright": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.0.tgz",
+      "integrity": "sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.0.tgz",
+      "integrity": "sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/postcss": {
       "version": "8.5.6",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@ai-sdk/react": "^1.1.19",
@@ -32,6 +33,7 @@
     "zustand": "^5.0.8"
   },
   "devDependencies": {
+    "@playwright/test": "^1.55.0",
     "@tailwindcss/postcss": "^4",
     "@tailwindcss/typography": "^0.5.16",
     "@types/node": "^20",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  fullyParallel: true,
+  retries: process.env.CI ? 2 : 0,
+  use: {
+    baseURL: 'http://127.0.0.1:3000',
+    trace: 'on-first-retry',
+  },
+  webServer: {
+    command: 'npm run dev -- --hostname 0.0.0.0 --port 3000',
+    url: 'http://127.0.0.1:3000',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120 * 1000,
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});

--- a/frontend/tests/chat-interface.spec.ts
+++ b/frontend/tests/chat-interface.spec.ts
@@ -1,0 +1,63 @@
+import { test, expect } from '@playwright/test';
+
+const mockSettings = {
+  system_prompt: 'You are a helpful assistant.',
+  tool_options: {
+    search: {
+      default_prompt: 'Search prompt',
+      settings: {},
+    },
+  },
+  search_portals: ['https://portal.example'],
+  model_options: {
+    MockProvider: [
+      { name: 'mock-model', max_tokens: 999 },
+    ],
+  },
+};
+
+test.describe('Chat interface', () => {
+  test('sends a message and renders agent response', async ({ page }) => {
+    await page.route('**/settings/options', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(mockSettings),
+      });
+    });
+
+    const mockResponse = {
+      messages: [
+        { type: 'human', content: 'Hello agent!' },
+        { type: 'ai', content: 'Mock agent response' },
+      ],
+      geodata_results: [],
+      geodata_layers: [],
+    };
+
+    await page.route('**/chat', async (route) => {
+      const request = route.request();
+      const payload = JSON.parse(request.postData() || '{}');
+      expect(payload.query).toBe('Hello agent!');
+
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(mockResponse),
+      });
+    });
+
+    await page.goto('/');
+
+    const chatInput = page.getByPlaceholder('Type a chat command...');
+    await chatInput.fill('Hello agent!');
+
+    await Promise.all([
+      page.waitForResponse('**/chat'),
+      chatInput.press('Enter'),
+    ]);
+
+    await expect(page.getByText('Hello agent!').first()).toBeVisible();
+    await expect(page.getByText('Mock agent response')).toBeVisible();
+  });
+});

--- a/frontend/tests/settings.spec.ts
+++ b/frontend/tests/settings.spec.ts
@@ -1,0 +1,44 @@
+import { test, expect } from '@playwright/test';
+
+const mockSettings = {
+  system_prompt: 'You are a helpful assistant.',
+  tool_options: {
+    search: {
+      default_prompt: 'Search prompt',
+      settings: {},
+    },
+  },
+  search_portals: ['https://portal.example'],
+  model_options: {
+    MockProvider: [
+      { name: 'mock-model', max_tokens: 999 },
+    ],
+  },
+};
+
+test.describe('Settings page', () => {
+  test('initializes settings from backend options', async ({ page }) => {
+    await page.route('**/settings/options', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(mockSettings),
+      });
+    });
+
+    await page.goto('/settings');
+
+    await expect(page.getByRole('heading', { level: 1, name: 'Settings' })).toBeVisible();
+
+    const providerSelect = page.locator('main select').first();
+    await expect(providerSelect).toContainText('MockProvider');
+    await expect(providerSelect).toHaveValue('MockProvider');
+
+    const modelSelect = page.locator('main select').nth(1);
+    await expect(modelSelect).toContainText('mock-model');
+    await expect(modelSelect).toHaveValue('mock-model');
+
+    const maxTokensInput = page.locator('main input[type="number"]').first();
+    await expect(maxTokensInput).toHaveValue('999');
+  });
+});


### PR DESCRIPTION
## Summary
- add Playwright configuration and end-to-end tests for the settings and chat interfaces with mocked backend responses
- add a Playwright test script and ignore generated artifacts in the frontend project
- extend the CI workflow to run frontend Playwright tests on pushes to main and on pull requests

## Testing
- npm run test:e2e

------
https://chatgpt.com/codex/tasks/task_e_68cef9909dec8329b83a096660634685