### PR TITLE
Fix runtime environment defaults for nginx and frontend

### DIFF
--- a/frontend/app/components/sidebar/LayerManagement.tsx
+++ b/frontend/app/components/sidebar/LayerManagement.tsx
@@ -5,6 +5,7 @@ import { useMapStore } from "../../stores/mapStore";
 import { useLayerStore } from "../../stores/layerStore";
 import { Eye, EyeOff, Trash2, Search, MapPin, GripVertical, Palette } from "lucide-react";
 import { formatFileSize, isFileSizeValid } from "../../utils/fileUtils";
+import { getUploadUrl } from "../../utils/apiBase";
 
 // Funny geo and data-themed loading messages
 const FUNNY_UPLOAD_MESSAGES = [
@@ -223,7 +224,7 @@ export default function LayerManagement() {
     setTotalFiles(files.length);
     setCurrentFileIndex(0);
 
-    const API_UPLOAD_URL = process.env.NEXT_PUBLIC_API_UPLOAD_URL || "http://localhost:8000/api/upload";
+    const API_UPLOAD_URL = getUploadUrl();
     const newLayers: any[] = [];
 
     try {

--- a/frontend/app/utils/apiBase.ts
+++ b/frontend/app/utils/apiBase.ts
@@ -13,3 +13,14 @@ export function getApiBase(): string {
   }
   return 'http://localhost:8000/api';
 }
+
+export function getUploadUrl(): string {
+  if (typeof window !== 'undefined') {
+    const runtime = (window as any).__RUNTIME_CONFIG__?.NEXT_PUBLIC_API_UPLOAD_URL;
+    if (runtime && runtime.trim() !== '') return runtime;
+  }
+  if (process.env.NEXT_PUBLIC_API_UPLOAD_URL && process.env.NEXT_PUBLIC_API_UPLOAD_URL.trim() !== '') {
+    return process.env.NEXT_PUBLIC_API_UPLOAD_URL;
+  }
+  return 'http://localhost:8000/api/upload';
+}

--- a/frontend/entrypoint.sh
+++ b/frontend/entrypoint.sh
@@ -2,15 +2,27 @@
 set -e
 
 # Generate a small JS file exposing runtime environment to the client.
+# Provide defaults so the browser never falls back to hard-coded localhost values.
+RUNTIME_API_BASE_URL="${NEXT_PUBLIC_API_BASE_URL:-/api}"
+RUNTIME_API_UPLOAD_URL="${NEXT_PUBLIC_API_UPLOAD_URL:-/api/upload}"
+RUNTIME_BACKEND_URL="${NEXT_PUBLIC_BACKEND_URL:-http://backend:8000}"
+
+# Ensure the defaults are also visible to the Next.js process.
+export NEXT_PUBLIC_API_BASE_URL="${RUNTIME_API_BASE_URL}"
+export NEXT_PUBLIC_API_UPLOAD_URL="${RUNTIME_API_UPLOAD_URL}"
+export NEXT_PUBLIC_BACKEND_URL="${RUNTIME_BACKEND_URL}"
+
 cat > /app/public/runtime-env.js <<EOF
 window.__RUNTIME_CONFIG__ = {
-  NEXT_PUBLIC_API_BASE_URL: "${NEXT_PUBLIC_API_BASE_URL}",
-  NEXT_PUBLIC_BACKEND_URL: "${NEXT_PUBLIC_BACKEND_URL}"
+  NEXT_PUBLIC_API_BASE_URL: "${RUNTIME_API_BASE_URL}",
+  NEXT_PUBLIC_API_UPLOAD_URL: "${RUNTIME_API_UPLOAD_URL}",
+  NEXT_PUBLIC_BACKEND_URL: "${RUNTIME_BACKEND_URL}"
 };
 EOF
 
 # Optional: log for debugging (will show in container logs, safe values only)
-echo "[entrypoint] Injected NEXT_PUBLIC_API_BASE_URL=${NEXT_PUBLIC_API_BASE_URL}"
-echo "[entrypoint] Injected NEXT_PUBLIC_BACKEND_URL=${NEXT_PUBLIC_BACKEND_URL}"
+echo "[entrypoint] Injected NEXT_PUBLIC_API_BASE_URL=${RUNTIME_API_BASE_URL}"
+echo "[entrypoint] Injected NEXT_PUBLIC_API_UPLOAD_URL=${RUNTIME_API_UPLOAD_URL}"
+echo "[entrypoint] Injected NEXT_PUBLIC_BACKEND_URL=${RUNTIME_BACKEND_URL}"
 
 exec "$@"

--- a/frontend/env.d.ts
+++ b/frontend/env.d.ts
@@ -6,6 +6,7 @@ declare global {
   interface Window {
     __RUNTIME_CONFIG__?: {
       NEXT_PUBLIC_API_BASE_URL?: string;
+      NEXT_PUBLIC_API_UPLOAD_URL?: string;
       NEXT_PUBLIC_BACKEND_URL?: string;
     };
   }

--- a/nginx/docker-entrypoint.sh
+++ b/nginx/docker-entrypoint.sh
@@ -1,5 +1,17 @@
 #!/bin/sh
 # Substitute environment variables in the Nginx config template and output the final config
+# Provide sensible defaults so the container does not fall back to Nginx defaults when
+# variables are missing.
+: "${BACKEND_PROTOCOL:=http}"
+: "${BACKEND_URL:=backend:8000}"
+: "${FRONTEND_PROTOCOL:=http}"
+: "${FRONTEND_URL:=frontend:3000}"
+
+echo "[entrypoint] Using BACKEND_PROTOCOL=${BACKEND_PROTOCOL}"
+echo "[entrypoint] Using BACKEND_URL=${BACKEND_URL}"
+echo "[entrypoint] Using FRONTEND_PROTOCOL=${FRONTEND_PROTOCOL}"
+echo "[entrypoint] Using FRONTEND_URL=${FRONTEND_URL}"
+
 envsubst '$BACKEND_PROTOCOL $BACKEND_URL $FRONTEND_PROTOCOL $FRONTEND_URL' < /etc/nginx/nginx.conf.envsubst > /etc/nginx/nginx.conf
 
 # Execute the command passed to the entrypoint (nginx)


### PR DESCRIPTION
## Summary
- default nginx proxy environment variables in the entrypoint so envsubst always receives values
- add runtime defaults for the Next.js container, export them to the process, and expose upload URL to the browser
- read the upload endpoint from a runtime-aware helper instead of hard-coded fallbacks in the sidebar upload flow

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dada558e2c8329881b27138fe47dff