### PR TITLE
Add backend API and tool test coverage

### DIFF
--- a/backend/tests/test_auto_styling_api.py
+++ b/backend/tests/test_auto_styling_api.py
@@ -1,0 +1,118 @@
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api import auto_styling
+
+
+@pytest.fixture
+def auto_styling_client():
+    app = FastAPI()
+    app.include_router(auto_styling.router)
+    return TestClient(app)
+
+
+def make_layer_payload(**overrides):
+    payload = {
+        "id": "layer-1",
+        "data_source_id": "source-1",
+        "data_type": "GeoJson",
+        "data_origin": "uploaded",
+        "data_source": "Test Source",
+        "data_link": "http://example.com/data.geojson",
+        "name": "Rivers of Africa",
+        "title": "Rivers of Africa",
+        "description": "Major rivers dataset",
+        "layer_type": "GeoJSON",
+        "visible": True,
+        "style": {
+            "stroke_color": "#3388f",
+            "fill_color": "#3388f",
+            "stroke_weight": 2,
+            "fill_opacity": 0.3,
+        },
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_auto_style_layers_returns_message_when_no_layers(auto_styling_client):
+    response = auto_styling_client.post("/auto-style", json={"layers": []})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["success"] is True
+    assert data["message"] == "No layers provided for styling"
+    assert data["styled_layers"] == []
+
+
+def test_auto_style_layers_returns_error_for_invalid_input(auto_styling_client):
+    response = auto_styling_client.post("/auto-style", json={"layers": [{"foo": "bar"}]})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["success"] is False
+    assert data["message"] == "No valid layers found for styling"
+    assert data["styled_layers"] == []
+
+
+def test_auto_style_layers_invokes_agent_and_returns_updated_layers(
+    auto_styling_client, monkeypatch
+):
+    updated_colors = {"stroke_color": "#123456", "fill_color": "#654321"}
+
+    class DummyAgent:
+        def __init__(self):
+            self.invocations = []
+
+        def invoke(self, state, debug=False):
+            self.invocations.append((state, debug))
+            # mutate first layer style to simulate agent styling
+            styled_layer = state["geodata_layers"][0]
+            styled_layer.style.stroke_color = updated_colors["stroke_color"]
+            styled_layer.style.fill_color = updated_colors["fill_color"]
+            return {"geodata_layers": state["geodata_layers"]}
+
+    dummy_agent = DummyAgent()
+    monkeypatch.setattr(auto_styling, "create_geo_agent", lambda: dummy_agent)
+
+    payload = {"layers": [make_layer_payload()]}
+    response = auto_styling_client.post("/auto-style", json=payload)
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["success"] is True
+    assert data["message"] == "Successfully applied automatic AI styling to 1 layer(s)"
+    assert len(data["styled_layers"]) == 1
+    styled_layer = data["styled_layers"][0]
+    assert styled_layer["style"]["stroke_color"] == updated_colors["stroke_color"]
+    assert styled_layer["style"]["fill_color"] == updated_colors["fill_color"]
+    assert dummy_agent.invocations, "Agent was not invoked"
+
+
+def test_auto_style_layers_returns_original_for_pre_styled_layer(
+    auto_styling_client, monkeypatch
+):
+    class DummyAgent:
+        def invoke(self, state, debug=False):
+            raise AssertionError("Agent should not be invoked for pre-styled layers")
+
+    monkeypatch.setattr(auto_styling, "create_geo_agent", lambda: DummyAgent())
+
+    custom_style = {
+        "stroke_color": "#000000",
+        "fill_color": "#ff9900",
+        "stroke_weight": 2,
+        "fill_opacity": 0.5,
+    }
+    layer_payload = make_layer_payload(style=custom_style)
+
+    response = auto_styling_client.post("/auto-style", json={"layers": [layer_payload]})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["success"] is True
+    assert (
+        data["message"]
+        == "No layers need automatic styling - all already have custom styling"
+    )
+    returned_style = data["styled_layers"][0]["style"]
+    for key, value in custom_style.items():
+        assert returned_style[key] == value

--- a/backend/tests/test_file_streaming_api.py
+++ b/backend/tests/test_file_streaming_api.py
@@ -1,0 +1,80 @@
+import json
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+from api import file_streaming
+from services.compression import gzip_utils
+
+
+@pytest.fixture
+def upload_dir(tmp_path, monkeypatch):
+    uploads = tmp_path / "uploads"
+    uploads.mkdir()
+    monkeypatch.setattr(file_streaming, "LOCAL_UPLOAD_DIR", str(uploads))
+    monkeypatch.setattr(gzip_utils, "LOCAL_UPLOAD_DIR", str(uploads))
+    return uploads
+
+
+@pytest.fixture
+def file_streaming_client(upload_dir):
+    app = FastAPI()
+    app.include_router(file_streaming.router)
+    return TestClient(app)
+
+
+def test_get_file_path_returns_resolved_path(upload_dir):
+    geojson = upload_dir / "data.geojson"
+    geojson.write_text("{}", encoding="utf-8")
+
+    resolved = file_streaming.get_file_path("data.geojson")
+    assert resolved == geojson.resolve()
+
+
+def test_get_file_path_rejects_missing_or_directory(upload_dir):
+    with pytest.raises(HTTPException) as exc:
+        file_streaming.get_file_path("missing.geojson")
+    assert exc.value.status_code == 404
+
+    subdir = upload_dir / "nested"
+    subdir.mkdir()
+    with pytest.raises(HTTPException) as exc:
+        file_streaming.get_file_path("nested")
+    assert exc.value.status_code == 400
+
+
+def test_stream_file_serves_full_content(file_streaming_client, upload_dir):
+    payload = {"type": "FeatureCollection", "features": []}
+    geojson = upload_dir / "sample.geojson"
+    geojson.write_text(json.dumps(payload), encoding="utf-8")
+
+    response = file_streaming_client.get("/stream/sample.geojson")
+    assert response.status_code == 200
+    assert response.headers["Content-Type"] == "application/geo+json"
+    assert response.content == geojson.read_bytes()
+
+
+def test_stream_file_supports_range_requests(file_streaming_client, upload_dir):
+    contents = b"0123456789abcdef"
+    geojson = upload_dir / "range.geojson"
+    geojson.write_bytes(contents)
+
+    response = file_streaming_client.get(
+        "/stream/range.geojson", headers={"Range": "bytes=2-5"}
+    )
+    assert response.status_code == 206
+    assert response.headers["Content-Range"] == f"bytes 2-5/{len(contents)}"
+    assert response.content == contents[2:6]
+
+
+def test_head_file_returns_metadata(file_streaming_client, upload_dir):
+    geojson = upload_dir / "metadata.geojson"
+    geojson.write_text("{\n  \"type\": \"FeatureCollection\"\n}", encoding="utf-8")
+
+    response = file_streaming_client.head("/stream/metadata.geojson")
+    assert response.status_code == 200
+    assert response.headers["Content-Type"] == "application/geo+json"
+    assert response.headers["Content-Length"] == str(geojson.stat().st_size)
+    assert response.headers["Accept-Ranges"] == "bytes"

--- a/backend/tests/test_geostate_management_tools.py
+++ b/backend/tests/test_geostate_management_tools.py
@@ -1,0 +1,117 @@
+import json
+
+import pytest
+from langchain_core.messages import HumanMessage, ToolMessage
+
+from services.tools import geostate_management
+from models.states import GeoDataAgentState
+
+
+@pytest.fixture
+def empty_state():
+    state = GeoDataAgentState()
+    state["messages"] = []
+    state["global_geodata"] = []
+    state["geodata_layers"] = []
+    state["geodata_last_results"] = []
+    return state
+
+
+def test_set_result_list_returns_matching_entries(empty_state, sample_river_layer, sample_building_layer):
+    empty_state["global_geodata"] = [sample_river_layer, sample_building_layer]
+
+    command = geostate_management.set_result_list.func(
+        state=empty_state,
+        tool_call_id="call-1",
+        results_title="Results",
+        result_tuples=[[sample_river_layer.id, sample_river_layer.data_source_id]],
+    )
+
+    assert sample_river_layer in command.update["geodata_results"]
+    tool_message = command.update["messages"][-1]
+    assert isinstance(tool_message, ToolMessage)
+    assert tool_message.name == "set_result_list"
+    assert "Successfully added" in tool_message.content
+
+
+def test_set_result_list_reports_missing_entries(empty_state, sample_river_layer):
+    empty_state["global_geodata"] = [sample_river_layer]
+
+    command = geostate_management.set_result_list.func(
+        state=empty_state,
+        tool_call_id="call-2",
+        results_title="",
+        result_tuples=[["missing", "unknown"]],
+    )
+
+    tool_message = command.update["messages"][-1]
+    assert "not found" in tool_message.content
+    assert command.update["geodata_results"] == []
+
+
+def test_list_global_geodata_returns_expected_structure(empty_state, sample_river_layer):
+    empty_state["global_geodata"] = [sample_river_layer]
+
+    result = geostate_management.list_global_geodata.func(state=empty_state)
+    assert result == [
+        {
+            "id": sample_river_layer.id,
+            "data_source_id": sample_river_layer.data_source_id,
+            "title": sample_river_layer.title,
+        }
+    ]
+
+
+def test_describe_geodata_object_returns_exact_match(empty_state, sample_river_layer):
+    empty_state["global_geodata"] = [sample_river_layer]
+
+    result = geostate_management.describe_geodata_object.func(
+        state=empty_state,
+        id=sample_river_layer.id,
+        data_source_id=sample_river_layer.data_source_id,
+    )
+    assert result == [sample_river_layer]
+
+
+@pytest.mark.parametrize("prioritize_layers", [True, False])
+def test_metadata_search_returns_relevant_dataset(
+    empty_state,
+    sample_river_layer,
+    sample_building_layer,
+    prioritize_layers,
+):
+    empty_state["messages"] = [HumanMessage("Describe dataset")]  # base history
+    empty_state["geodata_layers"] = [sample_river_layer]
+    empty_state["geodata_last_results"] = [sample_building_layer]
+
+    command = geostate_management.metadata_search.func(
+        state=empty_state,
+        tool_call_id="call-3",
+        query="rivers",
+        prioritize_layers=prioritize_layers,
+    )
+
+    tool_message = command.update["messages"][-1]
+    assert tool_message.name == "metadata_search"
+    assert "Found" in tool_message.content
+
+    _, payload = tool_message.content.split("\n\n", 1)
+    metadata = json.loads(payload)
+    assert metadata
+    top_entry = metadata[0]
+    assert top_entry["name"].lower().startswith("rivers")
+    assert top_entry["data_source"] == sample_river_layer.data_source
+
+
+def test_metadata_search_handles_no_matches(empty_state):
+    empty_state["messages"] = []
+    command = geostate_management.metadata_search.func(
+        state=empty_state,
+        tool_call_id="call-4",
+        query="unknown",
+        prioritize_layers=True,
+    )
+
+    tool_message = command.update["messages"][-1]
+    assert tool_message.name == "metadata_search"
+    assert "No datasets found" in tool_message.content


### PR DESCRIPTION
## Summary
- add FastAPI tests for the auto styling endpoint covering error handling, agent invocations, and pre-styled layers
- cover file streaming endpoint behaviour including sanitised path resolution, range requests, and HEAD metadata
- exercise geostate management tools to validate result list updates and metadata search responses

## Testing
- pytest tests/test_auto_styling_api.py tests/test_file_streaming_api.py tests/test_geostate_management_tools.py

------
https://chatgpt.com/codex/tasks/task_e_68e4515f5768832996fb5cf3e678cf9f