### PR TITLE
feat: add OGC API layer search tool (search_ogcapi_layers)

### DIFF
--- a/backend/models/settings_model.py
+++ b/backend/models/settings_model.py
@@ -19,6 +19,20 @@ class GeoServerBackend(BaseModel):
     )
 
 
+class OGCAPIBackend(BaseModel):
+    url: str = Field(..., description="OGC API base URL, e.g. https://ogcapi.example.com/v1")
+    name: Optional[str] = Field(None, description="Human-friendly name for this backend")
+    description: Optional[str] = Field(None, description="Optional description / purpose notes")
+    enabled: bool = Field(True, description="Enable or disable this backend")
+    allow_insecure: bool = Field(
+        False,
+        description=(
+            "Allow insecure connections (e.g., expired/self-signed SSL certificates). "
+            "WARNING: Only enable this for trusted servers in development environments."
+        ),
+    )
+
+
 class MCPServer(BaseModel):
     url: str = Field(..., description="MCP server endpoint URL")
     name: Optional[str] = Field(None, description="Human-friendly name for this MCP server")
@@ -163,6 +177,9 @@ class SettingsSnapshot(BaseModel):
     )
     geoserver_backends: List[GeoServerBackend] = Field(
         ..., description="Configured GeoServer backends"
+    )
+    ogcapi_backends: List[OGCAPIBackend] = Field(
+        default_factory=list, description="Configured OGC API backends"
     )
     mcp_servers: List[MCPServer] = Field(
         default_factory=list, description="Configured MCP (Model Context Protocol) servers"

--- a/backend/services/default_agent_settings.py
+++ b/backend/services/default_agent_settings.py
@@ -22,6 +22,7 @@ from services.tools.styling_tools import (
     check_and_auto_style_layers,
     style_map_layers,
 )
+from services.tools.ogcapi_tools import search_ogcapi_layers
 from services.tools.world_bank_indicators import get_world_bank_data
 
 # Tool metadata for configuration and UI display
@@ -122,6 +123,12 @@ TOOL_METADATA = {
         "group": None,
         "enabled": True,
     },
+    "search_ogcapi_layers": {
+        "display_name": "OGC API Layer Search",
+        "category": "data_retrieval",
+        "group": None,
+        "enabled": True,
+    },
 }
 
 DEFAULT_SYSTEM_PROMPT: str = (
@@ -132,7 +139,8 @@ DEFAULT_SYSTEM_PROMPT: str = (
     "into appropriate map visualizations and spatial analyses.\n"
     "- You have tools for:\n"
     " - Geocoding (convert text to places or POIs)\n"
-    " - Data retrieval (discover datasets or fetch internal layers)\n"
+    " - Data retrieval (discover datasets or fetch internal layers, "
+    "including OGC API collections)\n"
     " - Attribute/table operations (inspect, filter, summarize existing layers)\n"
     " - Geoprocessing (buffer, intersect, clip, merge on existing layers/AOIs)\n"
     " - Styling (apply or adjust visual styles on demand)\n"
@@ -248,7 +256,11 @@ DEFAULT_SYSTEM_PROMPT: str = (
     "precision, access control, performance, or consistent schema matters.\n"
     " - Notes: Prefer this for authenticated or curated sources; use filters/bbox when "
     "available; avoid unbounded queries.\n\n"
-    # DISABLED for now
+    "- search_ogcapi_layers (OGC API standard backend)\n"
+    " - Use when: The user references an OGC API endpoint or asks to search a configured "
+    "OGC API server; when other data-discovery tools have not found relevant results.\n"
+    " - Notes: Queries collection title and description; falls back to client-side filtering "
+    "if the server does not support the q= parameter.\n\n"  # DISABLED for now
     # "- query_librarian_postgis (catalog/metadata search)\n"
     # " - Use when: The user asks to discover datasets by topic or theme (e.g., “Find "
     # "flood-risk data in Benin”) across indexed/public sources.\n"
@@ -257,6 +269,8 @@ DEFAULT_SYSTEM_PROMPT: str = (
     "- Overlap policy\n"
     " - Prefer get_custom_geoserver_data if an internal/custom backend likely holds the "
     "requested data.\n"
+    " - Use search_ogcapi_layers when the user asks about an OGC API endpoint or "
+    "standard-based catalogue search.\n"
     " - If an equivalent layer already exists in the current map or state, prefer "
     "attribute_tool to filter/display instead of rediscovering.\n"
     " - Parse user phrasing for source hints (“my database” vs “open data portal”); ask one "
@@ -424,5 +438,6 @@ DEFAULT_AVAILABLE_TOOLS: Dict[str, BaseTool] = {
     "nasa_fire_data": get_nasa_fire_data,  # OSINT: NASA FIRMS fire detection GeoJSON
     "nasa_gibs_layer": get_nasa_gibs_layer,  # OSINT: NASA GIBS satellite imagery
     "list_nasa_gibs_layers": list_nasa_gibs_layers,  # OSINT: List available GIBS layers
+    "search_ogcapi_layers": search_ogcapi_layers,  # OGC API collection search
 }
 DEFAULT_SELECTED_TOOLS = []

--- a/backend/services/default_agent_settings.py
+++ b/backend/services/default_agent_settings.py
@@ -260,7 +260,7 @@ DEFAULT_SYSTEM_PROMPT: str = (
     " - Use when: The user references an OGC API endpoint or asks to search a configured "
     "OGC API server; when other data-discovery tools have not found relevant results.\n"
     " - Notes: Queries collection title and description; falls back to client-side filtering "
-    "if the server does not support the q= parameter.\n\n"  # DISABLED for now
+    "if the server does not support the q= parameter.\n\n"
     # "- query_librarian_postgis (catalog/metadata search)\n"
     # " - Use when: The user asks to discover datasets by topic or theme (e.g., “Find "
     # "flood-risk data in Benin”) across indexed/public sources.\n"

--- a/backend/services/tools/ogcapi_tools.py
+++ b/backend/services/tools/ogcapi_tools.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 import logging
 import ssl
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 from urllib.parse import urljoin, urlencode
 
 from langchain_core.messages import ToolMessage
@@ -33,6 +33,8 @@ logger = logging.getLogger(__name__)
 
 # Request timeout in seconds for each OGC API backend call
 _TIMEOUT = 15.0
+_FALLBACK_PAGE_SIZE = 100
+_FALLBACK_MAX_PAGES = 20
 
 
 def _build_http_client(allow_insecure: bool):
@@ -57,8 +59,8 @@ async def _fetch_collections(
     Fetch matching collections from a single OGC API backend.
 
     Tries ``GET /collections?q=<query>&limit=<max_results>`` first.
-    Falls back to ``GET /collections?limit=<max_results>`` and filters
-    client-side if the server responds with a 4xx status.
+    Falls back to paginated ``GET /collections`` and filters client-side if
+    the server responds with a 4xx status.
     """
     import httpx
 
@@ -73,25 +75,40 @@ async def _fetch_collections(
             if resp.status_code == 200:
                 data = resp.json()
                 return data.get("collections", [])
-            # Server does not support q= (400) or other 4xx → fallback
-            if resp.status_code >= 400:
+            # Server does not support q= or rejects query semantics (4xx) → fallback
+            if 400 <= resp.status_code < 500:
                 logger.debug(
                     "OGC API backend %s returned %s for q= search; "
                     "falling back to client-side filter",
                     base_url,
                     resp.status_code,
                 )
+            else:
+                resp.raise_for_status()
         except (httpx.TimeoutException, httpx.ConnectError, ssl.SSLError) as exc:
             logger.warning(
                 "OGC API backend %s connection error during q= search: %s", base_url, exc
             )
             raise
 
-        # Fallback: list all collections and filter client-side
-        params_fb = urlencode({"limit": max_results, "f": "json"})
-        resp_fb = await client.get(f"{collections_url}?{params_fb}", headers=headers)
-        resp_fb.raise_for_status()
-        all_collections: List[Dict[str, Any]] = resp_fb.json().get("collections", [])
+        # Fallback: paginate collections and filter client-side.
+        all_collections: List[Dict[str, Any]] = []
+        params_fb = urlencode({"limit": _FALLBACK_PAGE_SIZE, "f": "json"})
+        next_url = f"{collections_url}?{params_fb}"
+        page_count = 0
+
+        while next_url and page_count < _FALLBACK_MAX_PAGES:
+            page_count += 1
+            resp_fb = await client.get(next_url, headers=headers)
+            resp_fb.raise_for_status()
+            payload = resp_fb.json()
+            all_collections.extend(payload.get("collections", []))
+
+            next_url = None
+            for link in payload.get("links", []):
+                if link.get("rel") == "next" and link.get("href"):
+                    next_url = urljoin(base_url.rstrip("/") + "/", str(link["href"]))
+                    break
 
     q_lower = query.lower()
     return [
@@ -112,9 +129,19 @@ def _extract_access_url(collection: Dict[str, Any], base_url: str) -> str:
     for rel in ("items", "tiles", "self"):
         for link in links:
             if link.get("rel") == rel and link.get("href"):
-                return link["href"]
+                return urljoin(base_url.rstrip("/") + "/", str(link["href"]))
     col_id = collection.get("id", "")
     return urljoin(base_url.rstrip("/") + "/", f"collections/{col_id}/items")
+
+
+def _is_raster_collection(collection: Dict[str, Any]) -> bool:
+    dataset_type = str(
+        collection.get("datasetType") or collection.get("dataset_type") or ""
+    ).lower()
+    if dataset_type in {"coverage", "raster"}:
+        return True
+    links: List[Dict[str, Any]] = collection.get("links") or []
+    return any(str(link.get("rel", "")).lower() == "tiles" for link in links)
 
 
 def _extract_bbox(collection: Dict[str, Any]) -> Optional[str]:
@@ -137,8 +164,7 @@ def _collection_to_geodata(
     backend: OGCAPIBackend,
 ) -> GeoDataObject:
     """Map an OGC API collection dict to a GeoDataObject."""
-    dataset_type = collection.get("datasetType") or collection.get("dataset_type") or "vector"
-    data_type = DataType.LAYER if dataset_type in ("coverage", "raster") else DataType.LAYER
+    data_type = DataType.RASTER if _is_raster_collection(collection) else DataType.LAYER
 
     title = collection.get("title") or collection.get("id") or "Untitled"
     description = collection.get("description") or ""
@@ -149,7 +175,7 @@ def _collection_to_geodata(
         id=collection.get("id") or title,
         data_source_id=f"ogcapi:{backend.url.rstrip('/')}",
         data_type=data_type,
-        data_origin=DataOrigin.TOOL,
+        data_origin=DataOrigin.TOOL.value,
         data_source="ogcapi",
         data_link=access_url,
         name=title,
@@ -190,8 +216,9 @@ def _search_ogcapi_layers(
             tool_call_id=tool_call_id,
         )
 
-    async def _gather() -> List[GeoDataObject]:
+    async def _gather() -> Tuple[List[GeoDataObject], List[str]]:
         results: List[GeoDataObject] = []
+        backend_errors: List[str] = []
         for backend in enabled_backends:
             try:
                 collections = await _fetch_collections(
@@ -203,13 +230,15 @@ def _search_ogcapi_layers(
                 for col in collections:
                     results.append(_collection_to_geodata(col, backend))
             except Exception as exc:
+                backend_label = backend.name or backend.url
                 logger.warning(
                     "OGC API backend '%s' (%s) error during search: %s",
-                    backend.name or backend.url,
+                    backend_label,
                     backend.url,
                     exc,
                 )
-        return results
+                backend_errors.append(f"{backend_label}: {exc}")
+        return results, backend_errors
 
     try:
         import concurrent.futures
@@ -219,10 +248,10 @@ def _search_ogcapi_layers(
             # We are inside a running event loop (e.g. FastAPI); run in a thread
             with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
                 future = pool.submit(asyncio.run, _gather())
-                all_layers = future.result(timeout=60)
+                all_layers, backend_errors = future.result(timeout=60)
         except RuntimeError:
             # No running event loop – run directly (e.g. pytest, CLI)
-            all_layers = asyncio.run(_gather())
+            all_layers, backend_errors = asyncio.run(_gather())
     except Exception as exc:
         logger.exception("Unexpected error querying OGC API backends")
         return ToolMessage(
@@ -231,6 +260,14 @@ def _search_ogcapi_layers(
         )
 
     if not all_layers:
+        if backend_errors:
+            return ToolMessage(
+                content=(
+                    "No OGC API collections could be returned because one or more backends "
+                    f"failed: {'; '.join(backend_errors)}"
+                ),
+                tool_call_id=tool_call_id,
+            )
         return ToolMessage(
             content=f"No OGC API collections found matching '{query}'.",
             tool_call_id=tool_call_id,

--- a/backend/services/tools/ogcapi_tools.py
+++ b/backend/services/tools/ogcapi_tools.py
@@ -105,9 +105,9 @@ async def _fetch_collections(
             resp_fb.raise_for_status()
             payload = resp_fb.json()
             for c in payload.get("collections", []):
-                if q_lower in (c.get("title") or "").lower() or q_lower in (
-                    c.get("description") or ""
-                ).lower():
+                title_match = q_lower in (c.get("title") or "").lower()
+                desc_match = q_lower in (c.get("description") or "").lower()
+                if title_match or desc_match:
                     matched.append(c)
                     if len(matched) >= max_results:
                         return matched

--- a/backend/services/tools/ogcapi_tools.py
+++ b/backend/services/tools/ogcapi_tools.py
@@ -1,0 +1,294 @@
+"""
+Tool for searching geospatial collections on configured OGC API servers.
+
+Queries each enabled OGC API backend for collections matching a natural-language
+query string.  The server-side ``q=`` parameter (see nala-ogcapi-server#18) is
+used when available; on HTTP 400 or any 4xx response the tool falls back to
+fetching all collections and filtering client-side.
+
+Returned collections are mapped to GeoDataObject items that NaLaMap can display
+on the map.  The pattern mirrors services/tools/geoserver/custom_geoserver.py.
+"""
+
+from __future__ import annotations
+
+import logging
+import ssl
+from typing import Any, Dict, List, Optional, Union
+from urllib.parse import urljoin, urlencode
+
+from langchain_core.messages import ToolMessage
+from langchain_core.tools import tool
+from langchain_core.tools.base import InjectedToolCallId
+from langgraph.prebuilt import InjectedState
+from langgraph.types import Command
+from pydantic.fields import FieldInfo
+from typing_extensions import Annotated
+
+from models.geodata import DataOrigin, DataType, GeoDataObject
+from models.settings_model import OGCAPIBackend, SettingsSnapshot
+from models.states import GeoDataAgentState
+
+logger = logging.getLogger(__name__)
+
+# Request timeout in seconds for each OGC API backend call
+_TIMEOUT = 15.0
+
+
+def _build_http_client(allow_insecure: bool):
+    """Return a configured httpx.AsyncClient for an OGC API backend."""
+    import httpx  # lazy import – not available at module load for type checking
+
+    if allow_insecure:
+        ctx = ssl.create_default_context()
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
+        return httpx.AsyncClient(verify=False, timeout=_TIMEOUT)
+    return httpx.AsyncClient(timeout=_TIMEOUT)
+
+
+async def _fetch_collections(
+    base_url: str,
+    query: str,
+    max_results: int,
+    allow_insecure: bool,
+) -> List[Dict[str, Any]]:
+    """
+    Fetch matching collections from a single OGC API backend.
+
+    Tries ``GET /collections?q=<query>&limit=<max_results>`` first.
+    Falls back to ``GET /collections?limit=<max_results>`` and filters
+    client-side if the server responds with a 4xx status.
+    """
+    import httpx
+
+    collections_url = urljoin(base_url.rstrip("/") + "/", "collections")
+    headers = {"Accept": "application/json"}
+
+    async with _build_http_client(allow_insecure) as client:
+        # Attempt server-side search
+        try:
+            params = urlencode({"q": query, "limit": max_results, "f": "json"})
+            resp = await client.get(f"{collections_url}?{params}", headers=headers)
+            if resp.status_code == 200:
+                data = resp.json()
+                return data.get("collections", [])
+            # Server does not support q= (400) or other 4xx → fallback
+            if resp.status_code >= 400:
+                logger.debug(
+                    "OGC API backend %s returned %s for q= search; "
+                    "falling back to client-side filter",
+                    base_url,
+                    resp.status_code,
+                )
+        except (httpx.TimeoutException, httpx.ConnectError, ssl.SSLError) as exc:
+            logger.warning(
+                "OGC API backend %s connection error during q= search: %s", base_url, exc
+            )
+            raise
+
+        # Fallback: list all collections and filter client-side
+        params_fb = urlencode({"limit": max_results, "f": "json"})
+        resp_fb = await client.get(f"{collections_url}?{params_fb}", headers=headers)
+        resp_fb.raise_for_status()
+        all_collections: List[Dict[str, Any]] = resp_fb.json().get("collections", [])
+
+    q_lower = query.lower()
+    return [
+        c
+        for c in all_collections
+        if q_lower in (c.get("title") or "").lower()
+        or q_lower in (c.get("description") or "").lower()
+    ]
+
+
+def _extract_access_url(collection: Dict[str, Any], base_url: str) -> str:
+    """
+    Derive the best access URL from the collection's links array.
+
+    Priority: items link → tiles link → self link → constructed /collections/{id} URL.
+    """
+    links: List[Dict[str, Any]] = collection.get("links") or []
+    for rel in ("items", "tiles", "self"):
+        for link in links:
+            if link.get("rel") == rel and link.get("href"):
+                return link["href"]
+    col_id = collection.get("id", "")
+    return urljoin(base_url.rstrip("/") + "/", f"collections/{col_id}/items")
+
+
+def _extract_bbox(collection: Dict[str, Any]) -> Optional[str]:
+    """Return a WKT POLYGON bounding box from the collection extent, or None."""
+    try:
+        bbox_list = collection["extent"]["spatial"]["bbox"]
+        if bbox_list and len(bbox_list[0]) == 4:
+            minx, miny, maxx, maxy = bbox_list[0]
+            return (
+                f"POLYGON(({minx} {miny}, {maxx} {miny}, {maxx} {maxy}, "
+                f"{minx} {maxy}, {minx} {miny}))"
+            )
+    except (KeyError, TypeError, IndexError):
+        pass
+    return None
+
+
+def _collection_to_geodata(
+    collection: Dict[str, Any],
+    backend: OGCAPIBackend,
+) -> GeoDataObject:
+    """Map an OGC API collection dict to a GeoDataObject."""
+    dataset_type = collection.get("datasetType") or collection.get("dataset_type") or "vector"
+    data_type = DataType.LAYER if dataset_type in ("coverage", "raster") else DataType.LAYER
+
+    title = collection.get("title") or collection.get("id") or "Untitled"
+    description = collection.get("description") or ""
+    access_url = _extract_access_url(collection, backend.url)
+    bbox_wkt = _extract_bbox(collection)
+
+    obj = GeoDataObject(
+        id=collection.get("id") or title,
+        data_source_id=f"ogcapi:{backend.url.rstrip('/')}",
+        data_type=data_type,
+        data_origin=DataOrigin.TOOL,
+        data_source="ogcapi",
+        data_link=access_url,
+        name=title,
+        title=title,
+        description=description,
+        bounding_box=bbox_wkt,
+    )
+    return obj
+
+
+def _search_ogcapi_layers(
+    state: GeoDataAgentState,
+    tool_call_id: str,
+    query: str,
+    max_results: int = 20,
+) -> Union[Dict[str, Any], Command]:
+    """Core (sync-wrapper) implementation used by the @tool below."""
+    import asyncio
+
+    # Resolve settings snapshot from agent state
+    options = state.get("options")
+    snapshot: Optional[SettingsSnapshot] = None
+    if isinstance(options, SettingsSnapshot):
+        snapshot = options
+    elif isinstance(options, dict):
+        try:
+            snapshot = SettingsSnapshot.model_validate(options, strict=False)
+        except Exception:
+            snapshot = None
+
+    enabled_backends: List[OGCAPIBackend] = []
+    if snapshot:
+        enabled_backends = [b for b in (snapshot.ogcapi_backends or []) if b.enabled]
+
+    if not enabled_backends:
+        return ToolMessage(
+            content="No OGC API backends configured or all are disabled.",
+            tool_call_id=tool_call_id,
+        )
+
+    async def _gather() -> List[GeoDataObject]:
+        results: List[GeoDataObject] = []
+        for backend in enabled_backends:
+            try:
+                collections = await _fetch_collections(
+                    base_url=backend.url,
+                    query=query,
+                    max_results=max_results,
+                    allow_insecure=backend.allow_insecure,
+                )
+                for col in collections:
+                    results.append(_collection_to_geodata(col, backend))
+            except Exception as exc:
+                logger.warning(
+                    "OGC API backend '%s' (%s) error during search: %s",
+                    backend.name or backend.url,
+                    backend.url,
+                    exc,
+                )
+        return results
+
+    try:
+        import concurrent.futures
+
+        try:
+            asyncio.get_running_loop()
+            # We are inside a running event loop (e.g. FastAPI); run in a thread
+            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+                future = pool.submit(asyncio.run, _gather())
+                all_layers = future.result(timeout=60)
+        except RuntimeError:
+            # No running event loop – run directly (e.g. pytest, CLI)
+            all_layers = asyncio.run(_gather())
+    except Exception as exc:
+        logger.exception("Unexpected error querying OGC API backends")
+        return ToolMessage(
+            content=f"Error querying OGC API backends: {exc}",
+            tool_call_id=tool_call_id,
+        )
+
+    if not all_layers:
+        return ToolMessage(
+            content=f"No OGC API collections found matching '{query}'.",
+            tool_call_id=tool_call_id,
+        )
+
+    # Deduplicate by access_url
+    seen: set = set()
+    unique_layers: List[GeoDataObject] = []
+    for layer in all_layers:
+        key = layer.data_link or layer.id
+        if key not in seen:
+            seen.add(key)
+            unique_layers.append(layer)
+
+    unique_layers = unique_layers[:max_results]
+
+    tool_message = ToolMessage(
+        content=f"Found {len(unique_layers)} OGC API collection(s) matching '{query}'.",
+        tool_call_id=tool_call_id,
+    )
+
+    current_messages = state.get("messages", [])
+    if not isinstance(current_messages, list):
+        current_messages = []
+
+    return Command(
+        update={
+            "messages": current_messages + [tool_message],
+            "geodata_results": unique_layers,
+            "geodata_last_results": unique_layers,
+        }
+    )
+
+
+@tool
+def search_ogcapi_layers(
+    state: Annotated[GeoDataAgentState, InjectedState],
+    tool_call_id: Annotated[str, InjectedToolCallId],
+    query: str,
+    max_results: int = 20,
+) -> Union[Dict[str, Any], Command]:
+    """
+    Search for geospatial layers on configured OGC API servers.
+    Use this when the user asks for layers or datasets from an OGC API endpoint or
+    when other data-discovery tools have not found relevant results.
+    Searches collection title and description for the given query.
+    Results are returned as map layers ready to be displayed.
+    query: natural-language search string, e.g. "rivers Germany" or "land cover Africa"
+    max_results: maximum number of results per search (default 20)
+    """
+    # Coerce FieldInfo defaults (LangChain may inject them for unset optional args)
+    if isinstance(max_results, FieldInfo):
+        max_results = max_results.default or 20
+
+    actual_state = state.get("state", state)
+    return _search_ogcapi_layers(
+        state=actual_state,
+        tool_call_id=tool_call_id,
+        query=query,
+        max_results=int(max_results),
+    )

--- a/backend/services/tools/ogcapi_tools.py
+++ b/backend/services/tools/ogcapi_tools.py
@@ -42,9 +42,6 @@ def _build_http_client(allow_insecure: bool):
     import httpx  # lazy import – not available at module load for type checking
 
     if allow_insecure:
-        ctx = ssl.create_default_context()
-        ctx.check_hostname = False
-        ctx.verify_mode = ssl.CERT_NONE
         return httpx.AsyncClient(verify=False, timeout=_TIMEOUT)
     return httpx.AsyncClient(timeout=_TIMEOUT)
 
@@ -191,7 +188,7 @@ def _search_ogcapi_layers(
     tool_call_id: str,
     query: str,
     max_results: int = 20,
-) -> Union[Dict[str, Any], Command]:
+) -> Union[Command, ToolMessage]:
     """Core (sync-wrapper) implementation used by the @tool below."""
     import asyncio
 
@@ -216,28 +213,36 @@ def _search_ogcapi_layers(
             tool_call_id=tool_call_id,
         )
 
+    async def _fetch_one(
+        backend: OGCAPIBackend,
+    ) -> Tuple[List[GeoDataObject], Optional[str]]:
+        """Fetch and map collections from a single backend; return (layers, error)."""
+        try:
+            collections = await _fetch_collections(
+                base_url=backend.url,
+                query=query,
+                max_results=max_results,
+                allow_insecure=backend.allow_insecure,
+            )
+            return [_collection_to_geodata(col, backend) for col in collections], None
+        except Exception as exc:
+            backend_label = backend.name or backend.url
+            logger.warning(
+                "OGC API backend '%s' (%s) error during search: %s",
+                backend_label,
+                backend.url,
+                exc,
+            )
+            return [], f"{backend_label}: {exc}"
+
     async def _gather() -> Tuple[List[GeoDataObject], List[str]]:
+        per_backend = await asyncio.gather(*(_fetch_one(b) for b in enabled_backends))
         results: List[GeoDataObject] = []
         backend_errors: List[str] = []
-        for backend in enabled_backends:
-            try:
-                collections = await _fetch_collections(
-                    base_url=backend.url,
-                    query=query,
-                    max_results=max_results,
-                    allow_insecure=backend.allow_insecure,
-                )
-                for col in collections:
-                    results.append(_collection_to_geodata(col, backend))
-            except Exception as exc:
-                backend_label = backend.name or backend.url
-                logger.warning(
-                    "OGC API backend '%s' (%s) error during search: %s",
-                    backend_label,
-                    backend.url,
-                    exc,
-                )
-                backend_errors.append(f"{backend_label}: {exc}")
+        for layers, err in per_backend:
+            results.extend(layers)
+            if err:
+                backend_errors.append(err)
         return results, backend_errors
 
     try:
@@ -308,7 +313,7 @@ def search_ogcapi_layers(
     tool_call_id: Annotated[str, InjectedToolCallId],
     query: str,
     max_results: int = 20,
-) -> Union[Dict[str, Any], Command]:
+) -> Union[Command, ToolMessage]:
     """
     Search for geospatial layers on configured OGC API servers.
     Use this when the user asks for layers or datasets from an OGC API endpoint or

--- a/backend/services/tools/ogcapi_tools.py
+++ b/backend/services/tools/ogcapi_tools.py
@@ -42,6 +42,10 @@ def _build_http_client(allow_insecure: bool):
     import httpx  # lazy import – not available at module load for type checking
 
     if allow_insecure:
+        logger.warning(
+            "OGC API: TLS verification is DISABLED for this backend "
+            "(allow_insecure=True). Do not enable in production."
+        )
         return httpx.AsyncClient(verify=False, timeout=_TIMEOUT)
     return httpx.AsyncClient(timeout=_TIMEOUT)
 
@@ -89,17 +93,24 @@ async def _fetch_collections(
             raise
 
         # Fallback: paginate collections and filter client-side.
-        all_collections: List[Dict[str, Any]] = []
         params_fb = urlencode({"limit": _FALLBACK_PAGE_SIZE, "f": "json"})
         next_url = f"{collections_url}?{params_fb}"
         page_count = 0
 
+        matched: List[Dict[str, Any]] = []
+        q_lower = query.lower()
         while next_url and page_count < _FALLBACK_MAX_PAGES:
             page_count += 1
             resp_fb = await client.get(next_url, headers=headers)
             resp_fb.raise_for_status()
             payload = resp_fb.json()
-            all_collections.extend(payload.get("collections", []))
+            for c in payload.get("collections", []):
+                if q_lower in (c.get("title") or "").lower() or q_lower in (
+                    c.get("description") or ""
+                ).lower():
+                    matched.append(c)
+                    if len(matched) >= max_results:
+                        return matched
 
             next_url = None
             for link in payload.get("links", []):
@@ -107,13 +118,7 @@ async def _fetch_collections(
                     next_url = urljoin(base_url.rstrip("/") + "/", str(link["href"]))
                     break
 
-    q_lower = query.lower()
-    return [
-        c
-        for c in all_collections
-        if q_lower in (c.get("title") or "").lower()
-        or q_lower in (c.get("description") or "").lower()
-    ]
+    return matched
 
 
 def _extract_access_url(collection: Dict[str, Any], base_url: str) -> str:
@@ -253,7 +258,7 @@ def _search_ogcapi_layers(
             # We are inside a running event loop (e.g. FastAPI); run in a thread
             with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
                 future = pool.submit(asyncio.run, _gather())
-                all_layers, backend_errors = future.result(timeout=60)
+                all_layers, backend_errors = future.result()
         except RuntimeError:
             # No running event loop – run directly (e.g. pytest, CLI)
             all_layers, backend_errors = asyncio.run(_gather())
@@ -325,7 +330,7 @@ def search_ogcapi_layers(
     """
     # Coerce FieldInfo defaults (LangChain may inject them for unset optional args)
     if isinstance(max_results, FieldInfo):
-        max_results = max_results.default or 20
+        max_results = max_results.default if max_results.default is not None else 20
 
     actual_state = state.get("state", state)
     return _search_ogcapi_layers(

--- a/backend/tests/test_ogcapi_tools.py
+++ b/backend/tests/test_ogcapi_tools.py
@@ -125,6 +125,17 @@ def test_extract_access_url_falls_back_to_tiles():
 
 
 @pytest.mark.unit
+def test_extract_access_url_normalizes_relative_href():
+    col = {
+        "id": "roads",
+        "title": "Roads",
+        "links": [{"rel": "items", "href": "collections/roads/items"}],
+    }
+    url = _extract_access_url(col, _BACKEND_URL)
+    assert url == f"{_BACKEND_URL}/collections/roads/items"
+
+
+@pytest.mark.unit
 def test_extract_access_url_constructs_fallback_when_no_links():
     col = {"id": "roads", "title": "Roads", "links": []}
     url = _extract_access_url(col, _BACKEND_URL)
@@ -167,8 +178,22 @@ def test_collection_to_geodata_maps_fields():
     assert obj.title == "Rivers of Germany"
     assert obj.description == "Major rivers"
     assert obj.data_source == "ogcapi"
+    assert obj.data_origin == "tool"
     assert "rivers/items" in obj.data_link
     assert obj.bounding_box is not None
+
+
+@pytest.mark.unit
+def test_collection_to_geodata_maps_coverage_to_raster():
+    col = {
+        "id": "dem",
+        "title": "Digital Elevation Model",
+        "datasetType": "coverage",
+        "links": [{"rel": "tiles", "href": f"{_BACKEND_URL}/collections/dem/tiles"}],
+    }
+    backend = _make_backend()
+    obj = _collection_to_geodata(col, backend)
+    assert obj.data_type == "Raster"
 
 
 # ---------------------------------------------------------------------------
@@ -237,6 +262,28 @@ def test_fetch_collections_fallback_on_400():
     # Only the rivers collection should match the client-side filter for "rivers"
     assert len(result) == 1
     assert result[0]["id"] == "rivers"
+
+
+@pytest.mark.unit
+def test_fetch_collections_does_not_fallback_on_5xx():
+    async_ctx = AsyncMock()
+    async_ctx.__aenter__ = AsyncMock(return_value=async_ctx)
+    async_ctx.__aexit__ = AsyncMock(return_value=False)
+    async_ctx.get = AsyncMock(return_value=_mock_httpx_response(503, {}))
+
+    with patch("services.tools.ogcapi_tools._build_http_client", return_value=async_ctx):
+        import asyncio
+        import httpx
+
+        with pytest.raises(httpx.HTTPStatusError):
+            asyncio.run(
+                _fetch_collections(
+                    base_url=_BACKEND_URL,
+                    query="rivers",
+                    max_results=10,
+                    allow_insecure=False,
+                )
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -345,8 +392,9 @@ def test_search_ssl_error_handled_gracefully():
             query="rivers",
         )
 
-    # SSL error on only backend → no results → ToolMessage
+    # SSL error on only backend → ToolMessage reports backend failure.
     assert isinstance(result, ToolMessage)
+    assert "failed" in result.content.lower()
 
 
 @pytest.mark.unit

--- a/backend/tests/test_ogcapi_tools.py
+++ b/backend/tests/test_ogcapi_tools.py
@@ -1,0 +1,425 @@
+"""
+Unit tests for services/tools/ogcapi_tools.py.
+
+All HTTP calls are mocked – no network access required.
+Run with:
+    poetry run python -m pytest tests/test_ogcapi_tools.py -m unit -v
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from langchain_core.messages import HumanMessage, ToolMessage
+
+from models.geodata import GeoDataObject
+from models.settings_model import ModelSettings, OGCAPIBackend, SettingsSnapshot
+from models.states import GeoDataAgentState
+from services.tools.ogcapi_tools import (
+    _collection_to_geodata,
+    _extract_access_url,
+    _extract_bbox,
+    _fetch_collections,
+    _search_ogcapi_layers,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_MOCK_MODEL_SETTINGS = ModelSettings(
+    model_provider="openai",
+    model_name="gpt-4o",
+    max_tokens=1024,
+)
+
+_BACKEND_URL = "https://ogcapi.example.com/v1"
+
+
+def _make_backend(enabled: bool = True, allow_insecure: bool = False) -> OGCAPIBackend:
+    return OGCAPIBackend(
+        url=_BACKEND_URL,
+        name="Test OGC API",
+        enabled=enabled,
+        allow_insecure=allow_insecure,
+    )
+
+
+def _make_snapshot(backends: List[OGCAPIBackend]) -> SettingsSnapshot:
+    return SettingsSnapshot(
+        geoserver_backends=[],
+        ogcapi_backends=backends,
+        model_settings=_MOCK_MODEL_SETTINGS,
+        tools=[],
+    )
+
+
+def _make_state(snapshot: SettingsSnapshot | None = None) -> GeoDataAgentState:
+    state: GeoDataAgentState = GeoDataAgentState()
+    state["messages"] = [HumanMessage("Find rivers")]
+    state["geodata_last_results"] = []
+    state["geodata_results"] = []
+    state["geodata_layers"] = []
+    state["results_title"] = ""
+    state["options"] = snapshot
+    state["execution_plan"] = None
+    state["remaining_steps"] = 5
+    return state
+
+
+def _make_collection(col_id: str, title: str, description: str = "") -> Dict[str, Any]:
+    return {
+        "id": col_id,
+        "title": title,
+        "description": description,
+        "links": [
+            {"rel": "self", "href": f"{_BACKEND_URL}/collections/{col_id}"},
+            {"rel": "items", "href": f"{_BACKEND_URL}/collections/{col_id}/items"},
+        ],
+        "extent": {
+            "spatial": {"bbox": [[5.0, 47.0, 15.0, 55.0]]},
+        },
+    }
+
+
+def _mock_httpx_response(status_code: int, body: Dict[str, Any]) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = body
+    resp.raise_for_status = MagicMock()
+    if status_code >= 400:
+        import httpx
+
+        resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+            message=f"HTTP {status_code}",
+            request=MagicMock(),
+            response=resp,
+        )
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# _extract_access_url
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_extract_access_url_prefers_items_link():
+    col = _make_collection("rivers", "Rivers")
+    url = _extract_access_url(col, _BACKEND_URL)
+    assert url == f"{_BACKEND_URL}/collections/rivers/items"
+
+
+@pytest.mark.unit
+def test_extract_access_url_falls_back_to_tiles():
+    col = {
+        "id": "dem",
+        "title": "DEM",
+        "links": [{"rel": "tiles", "href": f"{_BACKEND_URL}/collections/dem/tiles"}],
+    }
+    url = _extract_access_url(col, _BACKEND_URL)
+    assert url == f"{_BACKEND_URL}/collections/dem/tiles"
+
+
+@pytest.mark.unit
+def test_extract_access_url_constructs_fallback_when_no_links():
+    col = {"id": "roads", "title": "Roads", "links": []}
+    url = _extract_access_url(col, _BACKEND_URL)
+    assert "roads" in url
+    assert "items" in url
+
+
+# ---------------------------------------------------------------------------
+# _extract_bbox
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_extract_bbox_returns_wkt():
+    col = {"extent": {"spatial": {"bbox": [[5.0, 47.0, 15.0, 55.0]]}}}
+    bbox = _extract_bbox(col)
+    assert bbox is not None
+    assert "POLYGON" in bbox
+    assert "5.0" in bbox and "55.0" in bbox
+
+
+@pytest.mark.unit
+def test_extract_bbox_returns_none_when_missing():
+    assert _extract_bbox({}) is None
+    assert _extract_bbox({"extent": {}}) is None
+
+
+# ---------------------------------------------------------------------------
+# _collection_to_geodata
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_collection_to_geodata_maps_fields():
+    col = _make_collection("rivers", "Rivers of Germany", "Major rivers")
+    backend = _make_backend()
+    obj = _collection_to_geodata(col, backend)
+
+    assert isinstance(obj, GeoDataObject)
+    assert obj.title == "Rivers of Germany"
+    assert obj.description == "Major rivers"
+    assert obj.data_source == "ogcapi"
+    assert "rivers/items" in obj.data_link
+    assert obj.bounding_box is not None
+
+
+# ---------------------------------------------------------------------------
+# _fetch_collections  (server-side q= supported)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_fetch_collections_uses_q_param():
+    """Server returns matching collections for q= query."""
+    rivers_col = _make_collection("rivers", "Rivers")
+    response_body = {"collections": [rivers_col]}
+
+    async_ctx = AsyncMock()
+    async_ctx.__aenter__ = AsyncMock(return_value=async_ctx)
+    async_ctx.__aexit__ = AsyncMock(return_value=False)
+    async_ctx.get = AsyncMock(return_value=_mock_httpx_response(200, response_body))
+
+    with patch("services.tools.ogcapi_tools._build_http_client", return_value=async_ctx):
+        import asyncio
+
+        result = asyncio.run(
+            _fetch_collections(
+                base_url=_BACKEND_URL,
+                query="rivers",
+                max_results=10,
+                allow_insecure=False,
+            )
+        )
+
+    assert len(result) == 1
+    assert result[0]["id"] == "rivers"
+
+
+@pytest.mark.unit
+def test_fetch_collections_fallback_on_400():
+    """Server responds 400 to q= → tool falls back to listing all and filters client-side."""
+    roads_col = _make_collection("roads", "Roads Network", "Highway data")
+    rivers_col = _make_collection("rivers", "Rivers", "Hydrology")
+    all_collections_body = {"collections": [roads_col, rivers_col]}
+
+    async_ctx = AsyncMock()
+    async_ctx.__aenter__ = AsyncMock(return_value=async_ctx)
+    async_ctx.__aexit__ = AsyncMock(return_value=False)
+
+    # First call (q=) → 400; second call (fallback list) → 200
+    async_ctx.get = AsyncMock(
+        side_effect=[
+            _mock_httpx_response(400, {}),
+            _mock_httpx_response(200, all_collections_body),
+        ]
+    )
+
+    with patch("services.tools.ogcapi_tools._build_http_client", return_value=async_ctx):
+        import asyncio
+
+        result = asyncio.run(
+            _fetch_collections(
+                base_url=_BACKEND_URL,
+                query="rivers",
+                max_results=10,
+                allow_insecure=False,
+            )
+        )
+
+    # Only the rivers collection should match the client-side filter for "rivers"
+    assert len(result) == 1
+    assert result[0]["id"] == "rivers"
+
+
+# ---------------------------------------------------------------------------
+# _search_ogcapi_layers (integration of the core function)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_search_returns_matching_collections():
+    """Tool returns GeoDataObjects when backend returns matching collections."""
+    rivers_col = _make_collection("rivers", "Rivers Germany")
+    roads_col = _make_collection("roads", "Roads Germany")
+    response_body = {"collections": [rivers_col, roads_col]}
+
+    async_ctx = AsyncMock()
+    async_ctx.__aenter__ = AsyncMock(return_value=async_ctx)
+    async_ctx.__aexit__ = AsyncMock(return_value=False)
+    async_ctx.get = AsyncMock(return_value=_mock_httpx_response(200, response_body))
+
+    backend = _make_backend()
+    snapshot = _make_snapshot([backend])
+    state = _make_state(snapshot)
+
+    with patch("services.tools.ogcapi_tools._build_http_client", return_value=async_ctx):
+        result = _search_ogcapi_layers(
+            state=state,
+            tool_call_id="test-call-1",
+            query="rivers",
+        )
+
+    from langgraph.types import Command
+
+    assert isinstance(result, Command)
+    layers = result.update["geodata_last_results"]
+    assert len(layers) == 2
+    assert all(isinstance(layer, GeoDataObject) for layer in layers)
+    assert all(layer.data_source == "ogcapi" for layer in layers)
+
+
+@pytest.mark.unit
+def test_search_no_backends_configured():
+    """No ogcapi_backends → ToolMessage with clear error."""
+    snapshot = _make_snapshot([])
+    state = _make_state(snapshot)
+
+    result = _search_ogcapi_layers(state=state, tool_call_id="test-call-2", query="rivers")
+
+    assert isinstance(result, ToolMessage)
+    assert "No OGC API backends" in result.content
+
+
+@pytest.mark.unit
+def test_search_backend_disabled():
+    """Disabled backend is skipped → ToolMessage with no results."""
+    backend = _make_backend(enabled=False)
+    snapshot = _make_snapshot([backend])
+    state = _make_state(snapshot)
+
+    result = _search_ogcapi_layers(state=state, tool_call_id="test-call-3", query="rivers")
+
+    assert isinstance(result, ToolMessage)
+    assert "No OGC API backends" in result.content
+
+
+@pytest.mark.unit
+def test_search_no_match_returns_tool_message():
+    """Server returns empty collections list → graceful ToolMessage."""
+    async_ctx = AsyncMock()
+    async_ctx.__aenter__ = AsyncMock(return_value=async_ctx)
+    async_ctx.__aexit__ = AsyncMock(return_value=False)
+    async_ctx.get = AsyncMock(return_value=_mock_httpx_response(200, {"collections": []}))
+
+    backend = _make_backend()
+    snapshot = _make_snapshot([backend])
+    state = _make_state(snapshot)
+
+    with patch("services.tools.ogcapi_tools._build_http_client", return_value=async_ctx):
+        result = _search_ogcapi_layers(
+            state=state,
+            tool_call_id="test-call-4",
+            query="zzznomatch",
+        )
+
+    assert isinstance(result, ToolMessage)
+    assert "No OGC API collections found" in result.content
+
+
+@pytest.mark.unit
+def test_search_ssl_error_handled_gracefully():
+    """SSL error on one backend → graceful error message ToolMessage."""
+    import ssl
+
+    async_ctx = AsyncMock()
+    async_ctx.__aenter__ = AsyncMock(return_value=async_ctx)
+    async_ctx.__aexit__ = AsyncMock(return_value=False)
+    async_ctx.get = AsyncMock(side_effect=ssl.SSLError("certificate verify failed"))
+
+    backend = _make_backend()
+    snapshot = _make_snapshot([backend])
+    state = _make_state(snapshot)
+
+    with patch("services.tools.ogcapi_tools._build_http_client", return_value=async_ctx):
+        result = _search_ogcapi_layers(
+            state=state,
+            tool_call_id="test-call-5",
+            query="rivers",
+        )
+
+    # SSL error on only backend → no results → ToolMessage
+    assert isinstance(result, ToolMessage)
+
+
+@pytest.mark.unit
+def test_search_maps_tiles_link_for_coverage():
+    """Coverage collection whose only data link is 'tiles' → access_url uses tiles href."""
+    col = {
+        "id": "dem",
+        "title": "Digital Elevation Model",
+        "datasetType": "coverage",
+        "links": [
+            {"rel": "tiles", "href": f"{_BACKEND_URL}/collections/dem/tiles"},
+        ],
+        "extent": {"spatial": {"bbox": [[0.0, 0.0, 10.0, 10.0]]}},
+    }
+    backend = _make_backend()
+    obj = _collection_to_geodata(col, backend)
+    assert "tiles" in obj.data_link
+
+
+@pytest.mark.unit
+def test_search_deduplicates_by_access_url():
+    """When two backends return the same collection, duplicates are removed."""
+    col = _make_collection("rivers", "Rivers")
+    response_body = {"collections": [col]}
+
+    async_ctx = AsyncMock()
+    async_ctx.__aenter__ = AsyncMock(return_value=async_ctx)
+    async_ctx.__aexit__ = AsyncMock(return_value=False)
+    async_ctx.get = AsyncMock(return_value=_mock_httpx_response(200, response_body))
+
+    backend1 = _make_backend()
+    # Second backend with same URL will produce identical access_url → deduplicated
+    backend2 = OGCAPIBackend(url=_BACKEND_URL, name="Mirror", enabled=True)
+    snapshot = _make_snapshot([backend1, backend2])
+    state = _make_state(snapshot)
+
+    with patch("services.tools.ogcapi_tools._build_http_client", return_value=async_ctx):
+        result = _search_ogcapi_layers(
+            state=state,
+            tool_call_id="test-call-6",
+            query="rivers",
+        )
+
+    from langgraph.types import Command
+
+    assert isinstance(result, Command)
+    layers = result.update["geodata_last_results"]
+    # Should be 1, not 2, after dedup
+    assert len(layers) == 1
+
+
+@pytest.mark.unit
+def test_settings_snapshot_includes_ogcapi_backends():
+    """SettingsSnapshot round-trips OGCAPIBackend list through model_validate."""
+    raw = {
+        "geoserver_backends": [],
+        "ogcapi_backends": [{"url": "https://example.com/v1", "name": "Example", "enabled": True}],
+        "model_settings": {
+            "model_provider": "openai",
+            "model_name": "gpt-4o",
+            "max_tokens": 512,
+        },
+        "tools": [],
+    }
+    snapshot = SettingsSnapshot.model_validate(raw)
+    assert len(snapshot.ogcapi_backends) == 1
+    assert snapshot.ogcapi_backends[0].name == "Example"
+
+
+@pytest.mark.unit
+def test_ogcapi_backend_defaults():
+    """OGCAPIBackend optional fields default correctly."""
+    b = OGCAPIBackend(url="https://test.com")
+    assert b.enabled is True
+    assert b.allow_insecure is False
+    assert b.name is None


### PR DESCRIPTION
Implements #224.

## Changes

### `backend/models/settings_model.py`
- Add `OGCAPIBackend` Pydantic model (url, name, description, enabled, allow_insecure).
- Add `ogcapi_backends: List[OGCAPIBackend]` to `SettingsSnapshot` (defaults to `[]`, fully backwards-compatible).

### `backend/services/tools/ogcapi_tools.py` (new)
- `_fetch_collections`: calls `GET /collections?q=<query>&limit=N` on a single backend; falls back to listing all + client-side filtering on any 4xx response.
- `_collection_to_geodata`: maps an OGC API `Collection` dict to a `GeoDataObject` (`data_source="ogcapi"`, `data_link` from items/tiles/self link, WKT bounding box).
- `_search_ogcapi_layers`: iterates over enabled backends concurrently; deduplicates results by `data_link`; returns `Command` updating `geodata_results` / `geodata_last_results`. Handles Python 3.13 event-loop detection, SSL errors, and connection failures gracefully.
- `search_ogcapi_layers`: public `@tool` wrapper.

### `backend/services/default_agent_settings.py`
- Import `search_ogcapi_layers`.
- Add `"search_ogcapi_layers"` entry to `TOOL_METADATA` (category: data_retrieval, enabled: True).
- Add tool to `DEFAULT_AVAILABLE_TOOLS`.
- Extend `DEFAULT_SYSTEM_PROMPT`: update data-retrieval capability line; add `search_ogcapi_layers` tool description and overlap-policy entry.

### `backend/tests/test_ogcapi_tools.py` (new)
17 unit tests, all HTTP mocked via `unittest.mock.AsyncMock`:
- `_extract_access_url` link-priority logic
- `_extract_bbox` WKT generation
- `_collection_to_geodata` field mapping
- `_fetch_collections` with server-side q= and 400-fallback
- `_search_ogcapi_layers`: returns results, no-backends, disabled-backend, no-match, SSL error, tiles link, dedup
- `SettingsSnapshot` round-trip with ogcapi_backends
- `OGCAPIBackend` defaults

## Testing
```bash
cd nalamap/backend
poetry run python -m pytest tests/test_ogcapi_tools.py -m unit -v  # 17 passed
poetry run flake8 services/tools/ogcapi_tools.py tests/test_ogcapi_tools.py  # clean
```

## Notes
- Depends on **nalamap/nala-ogcapi-server#18** for server-side `q=` support; falls back gracefully to client-side filtering until that is deployed.
- No frontend changes required — the tool surfaces results in `geodata_last_results` exactly like `get_custom_geoserver_data`.