### PR TITLE
feat(geocoding): Overpass address search via addr:* tags

### DIFF
--- a/backend/services/default_agent_settings.py
+++ b/backend/services/default_agent_settings.py
@@ -6,6 +6,7 @@ from services.tools.attribute_tool2 import attribute_tool2
 from services.tools.attribute_tools import attribute_tool
 from services.tools.ecmwf_weather import get_ecmwf_weather_data
 from services.tools.geocoding import (
+    geocode_address_via_overpass,
     geocode_using_nominatim_to_geostate,
     geocode_using_overpass_to_geostate,
 )
@@ -34,6 +35,12 @@ TOOL_METADATA = {
     },
     "geocode_overpass": {
         "display_name": "Overpass POI Search",
+        "category": "geocoding",
+        "group": None,
+        "enabled": True,
+    },
+    "geocode_address_overpass": {
+        "display_name": "Overpass Address Search",
         "category": "geocoding",
         "group": None,
         "enabled": True,
@@ -211,6 +218,13 @@ DEFAULT_SYSTEM_PROMPT: str = (
     " multiple relevant OSM tags and issues a union query, returning more complete results"
     " than a single-tag lookup would. You do not need to enumerate tags manually --"
     " pass the natural-language term directly as amenity_key.\n\n"
+    "- geocode_address_via_overpass (OSM addr:* tag address lookup)\n"
+    " - Use when: The user asks for a specific street address such as '221B Baker Street,\n"
+    "   London' or 'Hauptstraße 1, Berlin'.\n"
+    " - Inputs: street (required), housenumber, city, postcode (all optional).\n"
+    " - Notes: Finds OSM elements with matching addr:* tags. Prefer this over\n"
+    "   nominatim when the user wants the exact building on the map rather than\n"
+    "   just a location point. Providing city speeds up the search significantly.\n\n"
     "- Overlap policy\n"
     " - Prefer attribute_tool when an equivalent layer already exists and can be filtered.\n"
     " - Prefer nominatim for single places/boundaries; "
@@ -409,6 +423,7 @@ DEFAULT_AVAILABLE_TOOLS: Dict[str, BaseTool] = {
     # geocode_using_geonames, # its very simple and does not create a geojson
     "geocode_nominatim": geocode_using_nominatim_to_geostate,
     "geocode_overpass": geocode_using_overpass_to_geostate,
+    "geocode_address_overpass": geocode_address_via_overpass,
     # "search_librarian": query_librarian_postgis, # Librarian disconnected for now
     "geoprocess": geoprocess_tool,
     "search_metadata": metadata_search,

--- a/backend/services/tools/geocoding.py
+++ b/backend/services/tools/geocoding.py
@@ -812,9 +812,9 @@ def geocode_address_via_overpass(
         eid = f"{element.get('type', '')}/{element.get('id', '')}"
         if eid in seen_ids:
             continue
-        # Skip bare geometry nodes (no addr: tags) that were recursed in via (._; >;)
+        # Skip recursed helper elements that are not actual address-tagged matches.
         tags = element.get("tags", {})
-        if element.get("type") == "node" and not any(k.startswith("addr:") for k in tags):
+        if not any(k.startswith("addr:") for k in tags):
             continue
         feature = converter.convert_element_to_geojson(element, osm_tag_filter=None)
         if feature and feature.get("geometry"):

--- a/backend/services/tools/geocoding.py
+++ b/backend/services/tools/geocoding.py
@@ -698,6 +698,203 @@ def geocode_using_nominatim_to_geostate(
         return {"message": "Error querying the Nominatim API."}
 
 
+@tool
+def geocode_address_via_overpass(
+    state: Annotated[GeoDataAgentState, InjectedState],
+    tool_call_id: Annotated[str, InjectedToolCallId],
+    street: str,
+    housenumber: Optional[str] = None,
+    city: Optional[str] = None,
+    postcode: Optional[str] = None,
+    max_results: int = 50,
+    timeout: int = 60,
+) -> Union[Dict[str, Any], Command]:
+    """
+    Search for a specific street address using OSM addr:* tags via the Overpass API.
+
+    Use this when the user asks for a specific building or address, such as
+    "221B Baker Street, London" or "Alexanderplatz 1, Berlin 10178".
+    Returns OSM nodes/ways/relations tagged with matching address components.
+    Prefer geocode_using_nominatim_to_geostate for broad place or city searches.
+
+    street: Street name, e.g. "Baker Street" or "Hauptstraße"
+    housenumber: House or building number, e.g. "221B" or "42"
+    city: City name used to spatially constrain the search, e.g. "London"
+    postcode: Postal or ZIP code, e.g. "NW1 6XE" or "10178"
+    max_results: Maximum number of OSM elements to return (default 50)
+    timeout: Overpass API timeout in seconds (default 60)
+    """
+    # Build addr:* component dict from provided arguments
+    address_components: Dict[str, str] = {"addr:street": street}
+    if housenumber:
+        address_components["addr:housenumber"] = housenumber
+    if postcode:
+        address_components["addr:postcode"] = postcode
+    # addr:city is not added when it will be used as a location constraint below
+
+    # Geocode city to spatially constrain the query (prevents global scan)
+    location: Optional[OverpassLocation] = None
+    city_label = city or ""
+    if city:
+        location, err = _geocode_location_for_overpass(city)
+        if err or location is None:
+            # Fall back to adding city as an addr: filter instead
+            address_components["addr:city"] = city
+            location = None
+            city_label = city
+
+    query_description = street
+    if housenumber:
+        query_description = f"{housenumber} {street}"
+    if city_label:
+        query_description = f"{query_description}, {city_label}"
+    if postcode:
+        query_description = f"{query_description} {postcode}"
+
+    query_builder = OverpassQueryBuilder(timeout=timeout, max_results=max_results)
+    try:
+        overpass_query = query_builder.build_address_query(
+            address_components=address_components,
+            location=location,
+            radius_meters=50000,  # 50 km radius around city centre as fallback
+        )
+    except ValueError as exc:
+        return Command(
+            update={
+                "messages": [
+                    *state["messages"],
+                    ToolMessage(
+                        name="geocode_address_via_overpass",
+                        content=str(exc),
+                        tool_call_id=tool_call_id,
+                    ),
+                ]
+            }
+        )
+
+    client = OverpassClient()
+    overpass_data, error_msg = client.execute_query(overpass_query, timeout=timeout)
+
+    if error_msg:
+        return Command(
+            update={
+                "messages": [
+                    *state["messages"],
+                    ToolMessage(
+                        name="geocode_address_via_overpass",
+                        content=f"Overpass error while searching for '{query_description}': {error_msg}",
+                        tool_call_id=tool_call_id,
+                    ),
+                ]
+            }
+        )
+
+    elements = (overpass_data or {}).get("elements", [])
+    if not elements:
+        return Command(
+            update={
+                "messages": [
+                    *state["messages"],
+                    ToolMessage(
+                        name="geocode_address_via_overpass",
+                        content=f"No address found for '{query_description}' in OSM.",
+                        tool_call_id=tool_call_id,
+                    ),
+                ]
+            }
+        )
+
+    # Convert elements to GeoJSON features
+    converter = OverpassResultConverter()
+    features = []
+    seen_ids: set = set()
+    for element in elements:
+        eid = f"{element.get('type', '')}/{element.get('id', '')}"
+        if eid in seen_ids:
+            continue
+        # Skip bare geometry nodes (no addr: tags) that were recursed in via (._; >;)
+        tags = element.get("tags", {})
+        if element.get("type") == "node" and not any(k.startswith("addr:") for k in tags):
+            continue
+        feature = converter.convert_element_to_geojson(element, osm_tag_filter=None)
+        if feature and feature.get("geometry"):
+            seen_ids.add(eid)
+            features.append(feature)
+
+    features = converter.deduplicate_features(features)
+
+    if not features:
+        return Command(
+            update={
+                "messages": [
+                    *state["messages"],
+                    ToolMessage(
+                        name="geocode_address_via_overpass",
+                        content=f"Found OSM elements for '{query_description}' but none had usable geometry.",
+                        tool_call_id=tool_call_id,
+                    ),
+                ]
+            }
+        )
+
+    # Group by geometry type and build collections
+    location_label = location.display_name if location else "global"
+    collection_obj = create_feature_collection_geodata(
+        features,
+        "Address",
+        query_description,
+        location_label,
+        "addr:street",
+        city_label or street,
+    )
+
+    if not collection_obj:
+        return Command(
+            update={
+                "messages": [
+                    *state["messages"],
+                    ToolMessage(
+                        name="geocode_address_via_overpass",
+                        content=f"Could not create a map layer for '{query_description}'.",
+                        tool_call_id=tool_call_id,
+                    ),
+                ]
+            }
+        )
+
+    collection_obj.processing_metadata = ProcessingMetadata(
+        operation="overpass_address_query",
+        crs_used="EPSG:4326",
+        crs_name="WGS 84",
+        auto_selected=True,
+        query_intent=query_description,
+        query_location=city_label or street,
+        resolution_method="address_tags",
+        resolution_detail="OSM addr:* tag lookup",
+        osm_tags_used=[f"{k}={v}" for k, v in address_components.items()],
+        osm_tags_excluded=[],
+        overpass_query=overpass_query,
+    )
+
+    return Command(
+        update={
+            "messages": [
+                *state["messages"],
+                ToolMessage(
+                    name="geocode_address_via_overpass",
+                    content=(
+                        f"Found {len(features)} OSM feature(s) for address '{query_description}'. "
+                        "The result is available as a map layer."
+                    ),
+                    tool_call_id=tool_call_id,
+                ),
+            ],
+            "geodata_last_results": [collection_obj],
+            "geodata_results": [collection_obj],
+        }
+    )
+
+
 # Helper function to convert a single Overpass API element to a GeoJSON Feature dictionary
 def convert_osm_element_to_geojson_feature(
     element: Dict[str, Any], osm_tag_value_filter: Optional[str] = None

--- a/backend/services/tools/overpass.py
+++ b/backend/services/tools/overpass.py
@@ -363,6 +363,27 @@ class OverpassQueryBuilder:
         if not address_components:
             raise ValueError("address_components must not be empty")
 
+        valid_items: List[Tuple[str, str]] = []
+        for key, value in address_components.items():
+            if not key.startswith("addr:"):
+                raise ValueError("address_components must only contain addr:* keys")
+            if not re.fullmatch(r"addr:[A-Za-z0-9:_-]+", key):
+                raise ValueError(f"Invalid addr key: {key}")
+
+            normalized_value = str(value).strip()
+            if not normalized_value:
+                raise ValueError(f"address_components contains empty value for key '{key}'")
+
+            valid_items.append((key, normalized_value))
+
+        if not valid_items:
+            raise ValueError("address_components must contain at least one addr:* key")
+
+        def _escape_overpass_string(raw: str) -> str:
+            # Keep escaping consistent with JSON string escaping for quotes,
+            # backslashes and control chars.
+            return json.dumps(raw, ensure_ascii=False)[1:-1]
+
         parts = [f"[out:json][timeout:{self.timeout}][maxsize:{self.maxsize}];"]
 
         if location is not None:
@@ -381,8 +402,8 @@ class OverpassQueryBuilder:
             location_filter = ""
 
         tag_filters = "".join(
-            f'["{k}"="{v.replace(chr(34), chr(92) + chr(34))}"]'
-            for k, v in address_components.items()
+            f'["{key}"="{_escape_overpass_string(value)}"]'
+            for key, value in valid_items
         )
 
         parts.append("(")

--- a/backend/services/tools/overpass.py
+++ b/backend/services/tools/overpass.py
@@ -333,6 +333,68 @@ class OverpassQueryBuilder:
 
         return "\n".join(parts)
 
+    def build_address_query(
+        self,
+        address_components: Dict[str, str],
+        location: Optional[OverpassLocation] = None,
+        radius_meters: int = 10000,
+    ) -> str:
+        """
+        Build an Overpass QL query for structured address lookups using addr:* tags.
+
+        Constructs a multi-condition query that searches for OSM elements tagged
+        with all provided address components simultaneously, e.g.:
+            node["addr:street"="Baker Street"]["addr:housenumber"="221B"]["addr:city"="London"]
+
+        Args:
+            address_components: Mapping of addr:* tag names to values, e.g.
+                {"addr:street": "Baker Street", "addr:housenumber": "221B",
+                 "addr:city": "London"}.  Keys must start with "addr:".
+            location: Optional OverpassLocation to spatially constrain results.
+                When omitted the search is global (use sparingly).
+            radius_meters: Search radius for point-based location constraints.
+
+        Returns:
+            Overpass QL query string.
+
+        Raises:
+            ValueError: If address_components is empty or contains no addr:* keys.
+        """
+        if not address_components:
+            raise ValueError("address_components must not be empty")
+
+        parts = [f"[out:json][timeout:{self.timeout}][maxsize:{self.maxsize}];"]
+
+        if location is not None:
+            if location.has_area:
+                overpass_area_id = location.osm_relation_id + 3600000000
+                parts.append(f"area({overpass_area_id})->.search_area;")
+                location_filter = "(area.search_area)"
+            elif location.has_bbox:
+                s, w, n, e = location.bbox
+                location_filter = f"({s},{w},{n},{e})"
+            elif location.has_point:
+                location_filter = f"(around:{radius_meters},{location.lat},{location.lon})"
+            else:
+                location_filter = ""
+        else:
+            location_filter = ""
+
+        tag_filters = "".join(
+            f'["{k}"="{v.replace(chr(34), chr(92) + chr(34))}"]'
+            for k, v in address_components.items()
+        )
+
+        parts.append("(")
+        for osm_type in ("node", "way", "relation"):
+            parts.append(f"  {osm_type}{tag_filters}{location_filter};")
+        parts.append(");")
+        # Recurse into member nodes so way geometry is available
+        parts.append("(._; >;);")
+        parts.append(f"out geom {self.max_results};")
+
+        return "\n".join(parts)
+
     def build_center_query(
         self,
         osm_tag_key: str,

--- a/backend/services/tools/overpass.py
+++ b/backend/services/tools/overpass.py
@@ -402,8 +402,7 @@ class OverpassQueryBuilder:
             location_filter = ""
 
         tag_filters = "".join(
-            f'["{key}"="{_escape_overpass_string(value)}"]'
-            for key, value in valid_items
+            f'["{key}"="{_escape_overpass_string(value)}"]' for key, value in valid_items
         )
 
         parts.append("(")

--- a/backend/tests/test_overpass_address.py
+++ b/backend/tests/test_overpass_address.py
@@ -7,7 +7,10 @@ Tests cover:
 """
 
 import pytest
+from langgraph.types import Command
 
+from models.geodata import DataType, GeoDataObject
+from services.tools import geocoding as gc
 from services.tools.overpass import OverpassLocation, OverpassQueryBuilder
 
 
@@ -108,6 +111,155 @@ class TestBuildAddressQuery:
     def test_value_with_double_quote_escaped(self):
         """Double quotes in values are escaped to prevent Overpass QL injection."""
         query = self.builder.build_address_query({"addr:street": 'O"Brien Road'})
-        # Should not contain an unescaped bare double quote that would break the query
-        # The key/value is already wrapped in double quotes, so the inner quote must be escaped
-        assert '"addr:street"' in query
+        assert '"addr:street"="O\\"Brien Road"' in query
+        assert '"addr:street"="O"Brien Road"' not in query
+
+    def test_non_addr_key_raises(self):
+        with pytest.raises(ValueError, match=r"addr:\* keys"):
+            self.builder.build_address_query({"name": "Baker Street"})
+
+    def test_invalid_addr_key_characters_raise(self):
+        with pytest.raises(ValueError, match="Invalid addr key"):
+            self.builder.build_address_query({"addr:street\"]": "Baker Street"})
+
+
+@pytest.mark.unit
+class TestGeocodeAddressViaOverpass:
+    """Tests for geocode_address_via_overpass with mocked Overpass/Nominatim calls."""
+
+    def setup_method(self):
+        self.state = {"messages": [], "geodata_results": []}
+
+    def test_filters_recursed_non_address_elements_and_sets_metadata(self, monkeypatch):
+        location = OverpassLocation(
+            display_name="London",
+            osm_relation_id=65606,
+            lat=51.5074,
+            lon=-0.1278,
+        )
+        monkeypatch.setattr(gc, "_geocode_location_for_overpass", lambda city: (location, None))
+
+        captured = {}
+
+        def fake_execute_query(self, query, timeout=60):
+            captured["query"] = query
+            return (
+                {
+                    "elements": [
+                        {
+                            "type": "node",
+                            "id": 1,
+                            "lat": 51.5237,
+                            "lon": -0.1585,
+                            "tags": {"addr:street": "Baker Street", "addr:housenumber": "221B"},
+                        },
+                        {
+                            "type": "node",
+                            "id": 2,
+                            "lat": 51.5238,
+                            "lon": -0.1586,
+                            "tags": {},
+                        },
+                        {
+                            "type": "way",
+                            "id": 3,
+                            "tags": {},
+                            "geometry": [
+                                {"lat": 51.5237, "lon": -0.1585},
+                                {"lat": 51.5238, "lon": -0.1585},
+                            ],
+                        },
+                        {
+                            "type": "way",
+                            "id": 4,
+                            "tags": {"addr:street": "Baker Street", "addr:housenumber": "221B"},
+                            "geometry": [
+                                {"lat": 51.5237, "lon": -0.1585},
+                                {"lat": 51.5238, "lon": -0.1585},
+                            ],
+                        },
+                    ]
+                },
+                None,
+            )
+
+        monkeypatch.setattr(gc.OverpassClient, "execute_query", fake_execute_query)
+
+        captured_features = {}
+
+        def fake_create_feature_collection_geodata(
+            features,
+            data_source,
+            query,
+            location_name,
+            osm_tag_key,
+            osm_tag_value,
+        ):
+            captured_features["features"] = features
+            captured_features["query"] = query
+            captured_features["location_name"] = location_name
+            captured_features["osm_tag_key"] = osm_tag_key
+            captured_features["osm_tag_value"] = osm_tag_value
+            return GeoDataObject(
+                id="addr-layer",
+                data_source_id="addr-layer",
+                data_type=DataType.GEOJSON,
+                data_origin="tool",
+                data_source="Address",
+                data_link="/tmp/mock.geojson",
+                name="Address results",
+            )
+
+        monkeypatch.setattr(
+            gc,
+            "create_feature_collection_geodata",
+            fake_create_feature_collection_geodata,
+        )
+
+        result = gc.geocode_address_via_overpass.func(
+            state=self.state,
+            tool_call_id="tool-1",
+            street="Baker Street",
+            housenumber="221B",
+            city="London",
+        )
+
+        assert isinstance(result, Command)
+        assert '"addr:street"="Baker Street"' in captured["query"]
+        assert '"addr:housenumber"="221B"' in captured["query"]
+        assert "area(3600065606)" in captured["query"]
+
+        # Only address-tagged matches should remain after filtering recursed helpers.
+        assert len(captured_features["features"]) == 2
+
+        geodata = result.update["geodata_results"][0]
+        assert geodata.processing_metadata is not None
+        assert geodata.processing_metadata.operation == "overpass_address_query"
+        assert geodata.processing_metadata.resolution_method == "address_tags"
+        assert 'addr:street=Baker Street' in geodata.processing_metadata.osm_tags_used
+
+    def test_falls_back_to_addr_city_when_city_geocode_fails(self, monkeypatch):
+        monkeypatch.setattr(
+            gc,
+            "_geocode_location_for_overpass",
+            lambda city: (None, "Nominatim error"),
+        )
+
+        captured = {}
+
+        def fake_execute_query(self, query, timeout=60):
+            captured["query"] = query
+            return ({"elements": []}, None)
+
+        monkeypatch.setattr(gc.OverpassClient, "execute_query", fake_execute_query)
+
+        result = gc.geocode_address_via_overpass.func(
+            state=self.state,
+            tool_call_id="tool-2",
+            street="Main Street",
+            city="Berlin",
+        )
+
+        assert isinstance(result, Command)
+        assert '"addr:city"="Berlin"' in captured["query"]
+        assert "No address found" in result.update["messages"][-1].content

--- a/backend/tests/test_overpass_address.py
+++ b/backend/tests/test_overpass_address.py
@@ -1,0 +1,113 @@
+"""
+Unit tests for the Overpass address search feature (issue #100).
+
+Tests cover:
+- OverpassQueryBuilder.build_address_query()
+- geocode_address_via_overpass tool (mocked Overpass API)
+"""
+
+import pytest
+
+from services.tools.overpass import OverpassLocation, OverpassQueryBuilder
+
+
+@pytest.mark.unit
+class TestBuildAddressQuery:
+    """Tests for OverpassQueryBuilder.build_address_query()."""
+
+    def setup_method(self):
+        self.builder = OverpassQueryBuilder(timeout=60, max_results=50)
+
+    def test_street_only(self):
+        query = self.builder.build_address_query({"addr:street": "Baker Street"})
+        assert '[out:json]' in query
+        assert '"addr:street"="Baker Street"' in query
+        assert "node" in query
+        assert "way" in query
+        assert "relation" in query
+        # No location filter when location is None
+        assert "area(" not in query
+        assert "around:" not in query
+
+    def test_street_and_housenumber(self):
+        query = self.builder.build_address_query(
+            {"addr:street": "Baker Street", "addr:housenumber": "221B"}
+        )
+        assert '"addr:street"="Baker Street"' in query
+        assert '"addr:housenumber"="221B"' in query
+
+    def test_all_components(self):
+        components = {
+            "addr:street": "Baker Street",
+            "addr:housenumber": "221B",
+            "addr:city": "London",
+            "addr:postcode": "NW1 6XE",
+        }
+        query = self.builder.build_address_query(components)
+        for key, value in components.items():
+            assert f'"{key}"="{value}"' in query
+
+    def test_geometry_recursion_included(self):
+        """Ensure (._; >;) is present so member node geometry is available."""
+        query = self.builder.build_address_query({"addr:street": "Main Street"})
+        assert "(._; >;)" in query
+
+    def test_area_location_constraint(self):
+        location = OverpassLocation(
+            display_name="London",
+            osm_relation_id=65606,
+            lat=51.5074,
+            lon=-0.1278,
+        )
+        query = self.builder.build_address_query(
+            {"addr:street": "Baker Street"}, location=location
+        )
+        # Area ID = relation_id + 3600000000
+        assert "area(3600065606)" in query
+        assert "(area.search_area)" in query
+
+    def test_bbox_location_constraint(self):
+        location = OverpassLocation(
+            display_name="London",
+            bbox=(51.3, -0.5, 51.7, 0.3),
+            lat=51.5074,
+            lon=-0.1278,
+        )
+        query = self.builder.build_address_query(
+            {"addr:street": "Baker Street"}, location=location
+        )
+        assert "(51.3,-0.5,51.7,0.3)" in query
+
+    def test_point_location_constraint(self):
+        location = OverpassLocation(
+            display_name="Near Trafalgar Square",
+            lat=51.508,
+            lon=-0.128,
+        )
+        query = self.builder.build_address_query(
+            {"addr:street": "Baker Street"},
+            location=location,
+            radius_meters=5000,
+        )
+        assert "around:5000,51.508,-0.128" in query
+
+    def test_empty_components_raises(self):
+        with pytest.raises(ValueError, match="must not be empty"):
+            self.builder.build_address_query({})
+
+    def test_output_includes_max_results(self):
+        builder = OverpassQueryBuilder(timeout=60, max_results=25)
+        query = builder.build_address_query({"addr:street": "Main St"})
+        assert "out geom 25;" in query
+
+    def test_timeout_in_header(self):
+        builder = OverpassQueryBuilder(timeout=30, max_results=10)
+        query = builder.build_address_query({"addr:street": "Main St"})
+        assert "[timeout:30]" in query
+
+    def test_value_with_double_quote_escaped(self):
+        """Double quotes in values are escaped to prevent Overpass QL injection."""
+        query = self.builder.build_address_query({"addr:street": 'O"Brien Road'})
+        # Should not contain an unescaped bare double quote that would break the query
+        # The key/value is already wrapped in double quotes, so the inner quote must be escaped
+        assert '"addr:street"' in query

--- a/backend/tests/test_overpass_address.py
+++ b/backend/tests/test_overpass_address.py
@@ -31,7 +31,7 @@ class TestBuildAddressQuery:
 
     def test_street_only(self):
         query = self.builder.build_address_query({"addr:street": "Baker Street"})
-        assert '[out:json]' in query
+        assert "[out:json]" in query
         assert '"addr:street"="Baker Street"' in query
         assert "node" in query
         assert "way" in query
@@ -70,9 +70,7 @@ class TestBuildAddressQuery:
             lat=51.5074,
             lon=-0.1278,
         )
-        query = self.builder.build_address_query(
-            {"addr:street": "Baker Street"}, location=location
-        )
+        query = self.builder.build_address_query({"addr:street": "Baker Street"}, location=location)
         # Area ID = relation_id + 3600000000
         assert "area(3600065606)" in query
         assert "(area.search_area)" in query
@@ -84,9 +82,7 @@ class TestBuildAddressQuery:
             lat=51.5074,
             lon=-0.1278,
         )
-        query = self.builder.build_address_query(
-            {"addr:street": "Baker Street"}, location=location
-        )
+        query = self.builder.build_address_query({"addr:street": "Baker Street"}, location=location)
         assert "(51.3,-0.5,51.7,0.3)" in query
 
     def test_point_location_constraint(self):
@@ -128,7 +124,7 @@ class TestBuildAddressQuery:
 
     def test_invalid_addr_key_characters_raise(self):
         with pytest.raises(ValueError, match="Invalid addr key"):
-            self.builder.build_address_query({"addr:street\"]": "Baker Street"})
+            self.builder.build_address_query({'addr:street"]': "Baker Street"})
 
 
 @pytest.mark.unit
@@ -246,7 +242,7 @@ class TestGeocodeAddressViaOverpass:
         assert geodata.processing_metadata is not None
         assert geodata.processing_metadata.operation == "overpass_address_query"
         assert geodata.processing_metadata.resolution_method == "address_tags"
-        assert 'addr:street=Baker Street' in geodata.processing_metadata.osm_tags_used
+        assert "addr:street=Baker Street" in geodata.processing_metadata.osm_tags_used
 
     def test_falls_back_to_addr_city_when_city_geocode_fails(self, monkeypatch):
         monkeypatch.setattr(

--- a/backend/tests/test_overpass_address.py
+++ b/backend/tests/test_overpass_address.py
@@ -145,7 +145,9 @@ class TestGeocodeAddressViaOverpass:
             lat=51.5074,
             lon=-0.1278,
         )
-        monkeypatch.setattr(_GEOCODING_FUNC_MOD, "_geocode_location_for_overpass", lambda city: (location, None))
+        monkeypatch.setattr(
+            _GEOCODING_FUNC_MOD, "_geocode_location_for_overpass", lambda city: (location, None)
+        )
 
         captured = {}
 

--- a/backend/tests/test_overpass_address.py
+++ b/backend/tests/test_overpass_address.py
@@ -6,12 +6,20 @@ Tests cover:
 - geocode_address_via_overpass tool (mocked Overpass API)
 """
 
+import sys
+
 import pytest
 from langgraph.types import Command
 
 from models.geodata import DataType, GeoDataObject
 from services.tools import geocoding as gc
 from services.tools.overpass import OverpassLocation, OverpassQueryBuilder
+
+# The `geocoding` package re-exports symbols from a private legacy module loaded
+# under a different module name.  Monkeypatching `gc` only updates the package
+# namespace; the tool function looks up names in its own __globals__ which
+# belongs to the legacy module.  Helper below targets the right module.
+_GEOCODING_FUNC_MOD = sys.modules[gc.geocode_address_via_overpass.func.__module__]
 
 
 @pytest.mark.unit
@@ -137,7 +145,7 @@ class TestGeocodeAddressViaOverpass:
             lat=51.5074,
             lon=-0.1278,
         )
-        monkeypatch.setattr(gc, "_geocode_location_for_overpass", lambda city: (location, None))
+        monkeypatch.setattr(_GEOCODING_FUNC_MOD, "_geocode_location_for_overpass", lambda city: (location, None))
 
         captured = {}
 
@@ -211,7 +219,7 @@ class TestGeocodeAddressViaOverpass:
             )
 
         monkeypatch.setattr(
-            gc,
+            _GEOCODING_FUNC_MOD,
             "create_feature_collection_geodata",
             fake_create_feature_collection_geodata,
         )
@@ -240,7 +248,7 @@ class TestGeocodeAddressViaOverpass:
 
     def test_falls_back_to_addr_city_when_city_geocode_fails(self, monkeypatch):
         monkeypatch.setattr(
-            gc,
+            _GEOCODING_FUNC_MOD,
             "_geocode_location_for_overpass",
             lambda city: (None, "Nominatim error"),
         )


### PR DESCRIPTION
## Summary

Adds a new `geocode_address_via_overpass` agent tool and supporting infrastructure to enable precise building/address lookup via OSM `addr:*` tags (issue #100 — address search milestone).

## Changes

### `backend/services/tools/overpass.py`
- New `OverpassQueryBuilder.build_address_query(address_components, location, radius_meters)`: builds a multi-condition Overpass QL query that matches all provided `addr:*` tags on node/way/relation simultaneously, with optional spatial constraint via `OverpassLocation` (area, bbox, or radius around point).  Includes `(._; >;)` recursion so way member-node geometry is available.

### `backend/services/tools/geocoding.py`
- New `@tool geocode_address_via_overpass(street, housenumber, city, postcode, ...)`: geocodes the city via Nominatim for spatial constraint, builds the address query, strips bare geometry nodes from the recursive result, and returns a `Command` with a `GeoDataObject` collection including `ProcessingMetadata`.

### `backend/services/default_agent_settings.py`
- Import and register `geocode_address_overpass` in `TOOL_METADATA`, `DEFAULT_TOOL_REGISTRY`, and `DEFAULT_SYSTEM_PROMPT` with usage guidance.

### `backend/tests/test_overpass_address.py`
- 11 unit tests (`@pytest.mark.unit`): street-only, multi-component, location-constrained (area/bbox/point), empty-input error, max_results/timeout headers, double-quote escaping.

## Example
```python
# Agent calls:
geocode_address_via_overpass(
    street="Baker Street",
    housenumber="221B",
    city="London",
)
# → Overpass query: node["addr:street"="Baker Street"]["addr:housenumber"="221B"](area.search_area);
```

## Closes
Closes #100 (address search via addr:* tags)