### PR TITLE
feat(frontend): transparency slider for WMS/WMTS/WCS layers

### DIFF
--- a/backend/models/geodata.py
+++ b/backend/models/geodata.py
@@ -93,6 +93,9 @@ class GeoDataIdentifier(NamedTuple):
 class LayerStyle:
     """Enhanced style configuration for different geometry types"""
 
+    # Overall opacity for raster/tile layers (WMS, WMTS, WCS)
+    opacity: Optional[float] = None
+
     # Common stroke properties for all geometry types
     stroke_color: Optional[str] = "#3388f"
     stroke_weight: Optional[float] = 2

--- a/frontend/app/components/maps/LeafletMapClient.tsx
+++ b/frontend/app/components/maps/LeafletMapClient.tsx
@@ -1666,6 +1666,7 @@ export default function LeafletMapComponent() {
                     layers={wmsLayers}
                     format={format}
                     transparent={transparent}
+                    opacity={layer.style?.opacity ?? 1.0}
                     zIndex={10}
                   />
                 );
@@ -1678,6 +1679,7 @@ export default function LeafletMapComponent() {
                     layers={parsed.layers}
                     format={parsed.format}
                     transparent={parsed.transparent}
+                    opacity={layer.style?.opacity ?? 1.0}
                     zIndex={10}
                   />
                 );
@@ -1735,6 +1737,7 @@ export default function LeafletMapComponent() {
                     key={layer.id}
                     url={tileUrlTemplate}
                     attribution={layer.title}
+                    opacity={layer.style?.opacity ?? 1.0}
                   />
                 );
               } else if (

--- a/frontend/app/components/sidebar/LayerList.tsx
+++ b/frontend/app/components/sidebar/LayerList.tsx
@@ -600,6 +600,32 @@ export default function LayerList({
                       <h4 className="font-semibold text-sm mb-2">
                         Style Options
                       </h4>
+                      {["WMS", "WMTS", "WCS"].includes(
+                        layer.layer_type?.toUpperCase() || ""
+                      ) ? (
+                        <div className="text-xs">
+                          <label className="block text-gray-700">
+                            Transparency
+                          </label>
+                          <input
+                            type="range"
+                            min="0"
+                            max="1"
+                            step="0.05"
+                            value={layer.style?.opacity ?? 1.0}
+                            onChange={(e) =>
+                              updateLayerStyle(layer.id, {
+                                opacity: parseFloat(e.target.value),
+                              })
+                            }
+                            className="w-full"
+                          />
+                          <span className="text-gray-500">
+                            {Math.round((layer.style?.opacity ?? 1.0) * 100)}%
+                          </span>
+                        </div>
+                      ) : (
+                      <>
                       <div className="grid grid-cols-2 gap-2 text-xs">
                         {/* Stroke Color */}
                         <div>
@@ -986,6 +1012,8 @@ export default function LayerList({
                           />
                         </div>
                       </div>
+                      </>
+                      )}
                     </div>
                   )}
 

--- a/frontend/app/components/sidebar/LayerList.tsx
+++ b/frontend/app/components/sidebar/LayerList.tsx
@@ -605,7 +605,7 @@ export default function LayerList({
                       ) ? (
                         <div className="text-xs">
                           <label className="block text-gray-700">
-                            Transparency
+                            Opacity
                           </label>
                           <input
                             type="range"

--- a/frontend/app/models/geodatamodel.tsx
+++ b/frontend/app/models/geodatamodel.tsx
@@ -31,6 +31,9 @@ export interface ProcessingMetadata {
 }
 
 export interface LayerStyle {
+  // Overall opacity for raster/tile layers (WMS, WMTS, WCS) — 0.0 (transparent) to 1.0 (opaque)
+  opacity?: number;
+
   // Common stroke properties for all geometry types
   stroke_color?: string;
   stroke_weight?: number;


### PR DESCRIPTION
## Summary

Closes #189.

Users can now adjust the transparency of WMS, WMTS, and WCS tile layers via a dedicated slider in the layer styling panel. The styling panel for these raster layers is intentionally simplified — only the transparency control is shown, since stroke/fill styling is not applicable.

## Changes

### `frontend/app/models/geodatamodel.tsx`
- Added `opacity?: number` to `LayerStyle` interface (0.0 = transparent, 1.0 = opaque). Used only for tile/raster layers; vector layers continue using `stroke_opacity`/`fill_opacity`.

### `frontend/app/components/maps/LeafletMapClient.tsx`
- Pass `opacity={layer.style?.opacity ?? 1.0}` to `WMSTileLayer` for WMS and WCS layers
- Pass `opacity={layer.style?.opacity ?? 1.0}` to `TileLayer` for WMTS layers
- Leaflet applies changes reactively via `setOpacity()` — no remount needed

### `frontend/app/components/sidebar/LayerList.tsx`
- Style panel now branches on `layer_type`:
  - **WMS / WMTS / WCS**: shows only a `Transparency` range slider (0–100%)
  - **WFS / UPLOADED / GeoJSON**: full vector styling panel unchanged