### PR TITLE
feat: add OGC API layer search tool

### DIFF
--- a/backend/models/settings_model.py
+++ b/backend/models/settings_model.py
@@ -36,6 +36,20 @@ class MCPServer(BaseModel):
     )
 
 
+class OGCAPIBackend(BaseModel):
+    url: str = Field(..., description="OGC API base URL, e.g. https://ogcapi.example.com/v1")
+    name: str = Field(..., description="Human-friendly name for this backend")
+    description: Optional[str] = Field(None, description="Optional description / purpose notes")
+    enabled: bool = Field(True, description="Enable or disable this backend")
+    allow_insecure: bool = Field(
+        False,
+        description=(
+            "Allow insecure connections (e.g., expired/self-signed SSL certificates). "
+            "WARNING: Only enable this for trusted servers in development environments."
+        ),
+    )
+
+
 class SearchPortal(BaseModel):
     url: str = Field(..., description="Geodata portal URL")
     enabled: bool = Field(True, description="Enable or disable this portal")
@@ -163,6 +177,9 @@ class SettingsSnapshot(BaseModel):
     )
     geoserver_backends: List[GeoServerBackend] = Field(
         ..., description="Configured GeoServer backends"
+    )
+    ogcapi_backends: List[OGCAPIBackend] = Field(
+        default_factory=list, description="Configured OGC API backends"
     )
     mcp_servers: List[MCPServer] = Field(
         default_factory=list, description="Configured MCP (Model Context Protocol) servers"

--- a/backend/services/default_agent_settings.py
+++ b/backend/services/default_agent_settings.py
@@ -13,6 +13,7 @@ from services.tools.geocoding import (
 from services.tools.geoprocess_tools import geoprocess_tool
 from services.tools.geoserver.custom_geoserver import get_custom_geoserver_data
 from services.tools.geostate_management import metadata_search
+from services.tools.ogcapi_tools import search_ogcapi_layers
 from services.tools.nasa_firms_fire import get_nasa_fire_data
 from services.tools.nasa_gibs_imagery import get_nasa_gibs_layer, list_nasa_gibs_layers
 
@@ -83,6 +84,12 @@ TOOL_METADATA = {
     },
     "get_custom_geoserver_data": {
         "display_name": "Custom GeoServer Data",
+        "category": "data_retrieval",
+        "group": None,
+        "enabled": True,
+    },
+    "search_ogcapi_layers": {
+        "display_name": "OGC API Layer Search",
         "category": "data_retrieval",
         "group": None,
         "enabled": True,
@@ -257,6 +264,11 @@ DEFAULT_SYSTEM_PROMPT: str = (
     "something else.'\n\n"
     "## DATA RETRIEVAL \n"
     "- Purpose: Find, preview, and fetch geospatial datasets and layers.\n\n"
+    "- search_ogcapi_layers (OGC API backend)\n"
+    " - Use when: The user asks for layers from an OGC API endpoint or a configured OGC API "
+    "backend, e.g. 'show me protected areas from our OGC API'.\n"
+    " - Notes: Searches collection title, description, and id; falls back to client-side "
+    "filtering when the server does not support q= search.\n\n"
     "- get_custom_geoserver_data (org/internal backend)\n"
     " - Use when: The user references “my/our database” or known internal layers; when "
     "precision, access control, performance, or consistent schema matters.\n"
@@ -432,6 +444,7 @@ DEFAULT_AVAILABLE_TOOLS: Dict[str, BaseTool] = {
     "check_and_autostyle": check_and_auto_style_layers,  # Automatic layer style checker
     "apply_color_scheme": apply_intelligent_color_scheme,
     "get_custom_geoserver_data": get_custom_geoserver_data,
+    "search_ogcapi_layers": search_ogcapi_layers,
     "attribute_tool": attribute_tool,
     "attribute_tool2": attribute_tool2,  # Simplified attribute tool for better agent usability
     "world_bank_indicators": get_world_bank_data,  # OSINT: World Bank economic indicators

--- a/backend/services/tools/geocoding.py
+++ b/backend/services/tools/geocoding.py
@@ -841,10 +841,10 @@ def geocode_address_via_overpass(
     location_label = location.display_name if location else "global"
     collection_obj = create_feature_collection_geodata(
         features,
-        "Address",
+        "Points",
         query_description,
         location_label,
-        "addr:street",
+        f"addr:street={street}",
         city_label or street,
     )
 

--- a/backend/services/tools/geocoding.py
+++ b/backend/services/tools/geocoding.py
@@ -660,7 +660,6 @@ def geocode_using_nominatim_to_geostate(
                 return Command(
                     update={
                         "messages": [
-                            *state["messages"],
                             ToolMessage(
                                 name="geocode_using_nominatim_to_geostate",
                                 content=tool_message_content,
@@ -762,7 +761,6 @@ def geocode_address_via_overpass(
         return Command(
             update={
                 "messages": [
-                    *state["messages"],
                     ToolMessage(
                         name="geocode_address_via_overpass",
                         content=str(exc),
@@ -779,7 +777,6 @@ def geocode_address_via_overpass(
         return Command(
             update={
                 "messages": [
-                    *state["messages"],
                     ToolMessage(
                         name="geocode_address_via_overpass",
                         content=f"Overpass error while searching for '{query_description}': {error_msg}",
@@ -794,7 +791,6 @@ def geocode_address_via_overpass(
         return Command(
             update={
                 "messages": [
-                    *state["messages"],
                     ToolMessage(
                         name="geocode_address_via_overpass",
                         content=f"No address found for '{query_description}' in OSM.",
@@ -827,7 +823,6 @@ def geocode_address_via_overpass(
         return Command(
             update={
                 "messages": [
-                    *state["messages"],
                     ToolMessage(
                         name="geocode_address_via_overpass",
                         content=f"Found OSM elements for '{query_description}' but none had usable geometry.",
@@ -852,7 +847,6 @@ def geocode_address_via_overpass(
         return Command(
             update={
                 "messages": [
-                    *state["messages"],
                     ToolMessage(
                         name="geocode_address_via_overpass",
                         content=f"Could not create a map layer for '{query_description}'.",
@@ -879,7 +873,6 @@ def geocode_address_via_overpass(
     return Command(
         update={
             "messages": [
-                *state["messages"],
                 ToolMessage(
                     name="geocode_address_via_overpass",
                     content=(
@@ -1313,7 +1306,6 @@ def geocode_using_overpass_to_geostate(
         return Command(
             update={
                 "messages": [
-                    *state["messages"],
                     ToolMessage(
                         name="geocode_using_overpass_to_geostate",
                         content=hint,
@@ -1352,7 +1344,6 @@ def geocode_using_overpass_to_geostate(
             return Command(
                 update={
                     "messages": [
-                        *state["messages"],
                         ToolMessage(
                             name="geocode_using_overpass_to_geostate",
                             content=error_msg,
@@ -1400,7 +1391,6 @@ def geocode_using_overpass_to_geostate(
         return Command(
             update={
                 "messages": [
-                    *state["messages"],
                     ToolMessage(
                         name="geocode_using_overpass_to_geostate",
                         content=str(e),
@@ -1418,7 +1408,6 @@ def geocode_using_overpass_to_geostate(
         return Command(
             update={
                 "messages": [
-                    *state["messages"],
                     ToolMessage(
                         name="geocode_using_overpass_to_geostate",
                         content=(
@@ -1436,7 +1425,6 @@ def geocode_using_overpass_to_geostate(
         return Command(
             update={
                 "messages": [
-                    *state["messages"],
                     ToolMessage(
                         name="geocode_using_overpass_to_geostate",
                         content=(f"No '{amenity_key_display}' found {search_mode_description}."),
@@ -1581,7 +1569,6 @@ def geocode_using_overpass_to_geostate(
         return Command(
             update={
                 "messages": [
-                    *state["messages"],
                     ToolMessage(
                         name="geocode_using_overpass_to_geostate",
                         content=(
@@ -1615,7 +1602,6 @@ def geocode_using_overpass_to_geostate(
 
     state_update: Dict[str, Any] = {
         "messages": [
-            *state["messages"],
             ToolMessage(
                 name="geocode_using_overpass_to_geostate",
                 content=tool_message_content,

--- a/backend/services/tools/ogcapi_tools.py
+++ b/backend/services/tools/ogcapi_tools.py
@@ -1,0 +1,258 @@
+"""OGC API Layer Search Tool.
+
+Queries one or more configured OGC API – Features/Tiles servers for collections
+matching a natural-language query, and returns them as GeoDataObject items that
+NaLaMap can display on the map.
+
+Server-side ``q=`` full-text search is attempted first (OGC API – Common Part 2
+conformance).  When the server returns HTTP 400 or yields no results, the tool
+falls back to listing all collections and filtering client-side via substring
+match on ``title`` and ``description``.
+"""
+
+import logging
+import ssl
+import uuid
+from typing import Any, Dict, List, Optional, Union
+
+import httpx
+from langchain_core.messages import ToolMessage
+from langchain_core.tools import tool
+from langchain_core.tools.base import InjectedToolCallId
+from langgraph.prebuilt import InjectedState
+from langgraph.types import Command
+from typing_extensions import Annotated
+
+from models.geodata import DataOrigin, DataType, GeoDataObject
+from models.settings_model import OGCAPIBackend, SettingsSnapshot
+from models.states import GeoDataAgentState
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_TIMEOUT = 15.0  # seconds
+_MAX_RESULTS = 50  # upper bound to avoid oversized ToolMessage
+
+
+def _make_client(allow_insecure: bool) -> httpx.Client:
+    """Return a synchronous httpx client, optionally skipping TLS verification."""
+    if allow_insecure:
+        return httpx.Client(verify=False, timeout=_DEFAULT_TIMEOUT)
+    return httpx.Client(timeout=_DEFAULT_TIMEOUT)
+
+
+def _pick_access_url(collection: Dict[str, Any], base_url: str) -> str:
+    """Extract the best access URL from a collection's links array.
+
+    Preference order: tiles link → items link → self link → base_url/collection_id.
+    """
+    links: List[Dict[str, Any]] = collection.get("links", [])
+    for rel in ("tiles", "items", "self"):
+        for link in links:
+            if link.get("rel") == rel and link.get("href"):
+                return link["href"]
+    col_id = collection.get("id", "")
+    return f"{base_url.rstrip('/')}/collections/{col_id}/items" if col_id else base_url
+
+
+def _extract_bbox_wkt(collection: Dict[str, Any]) -> Optional[str]:
+    """Return a WKT POLYGON bbox string from the collection's spatial extent, if present."""
+    try:
+        bbox = collection.get("extent", {}).get("spatial", {}).get("bbox", [[]])[0]
+        if bbox and len(bbox) >= 4:
+            min_lon, min_lat, max_lon, max_lat = (
+                float(bbox[0]),
+                float(bbox[1]),
+                float(bbox[2]),
+                float(bbox[3]),
+            )
+            return (
+                f"POLYGON(("
+                f"{max_lon} {min_lat}, {max_lon} {max_lat}, "
+                f"{min_lon} {max_lat}, {min_lon} {min_lat}, "
+                f"{max_lon} {min_lat}"
+                f"))"
+            )
+    except (KeyError, IndexError, TypeError, ValueError):
+        pass
+    return None
+
+
+def _collection_to_geodata(
+    collection: Dict[str, Any],
+    backend: OGCAPIBackend,
+) -> GeoDataObject:
+    """Map an OGC API collection dict to a GeoDataObject."""
+    col_id = collection.get("id", "")
+    access_url = _pick_access_url(collection, backend.url)
+    bbox_wkt = _extract_bbox_wkt(collection)
+    return GeoDataObject(
+        id=str(uuid.uuid4()),
+        name=col_id,
+        title=collection.get("title") or col_id or "Untitled",
+        description=collection.get("description") or "",
+        data_type=DataType.LAYER,
+        data_source="ogcapi",
+        data_source_id=backend.name,
+        data_origin=DataOrigin.TOOL.value,
+        data_link=access_url,
+        bounding_box=bbox_wkt,
+        properties={
+            "collection_id": col_id,
+            "backend_name": backend.name,
+            "backend_url": backend.url,
+        },
+    )
+
+
+def _search_backend(
+    backend: OGCAPIBackend,
+    query: str,
+    max_results: int,
+) -> List[GeoDataObject]:
+    """Query a single OGC API backend and return matching GeoDataObjects.
+
+    Tries server-side ``?q=`` search first; falls back to client-side filtering
+    if the server returns HTTP 400 or does not support the parameter.
+    """
+    base = backend.url.rstrip("/")
+
+    try:
+        with _make_client(backend.allow_insecure) as client:
+            # --- Attempt 1: server-side q= search ---
+            try:
+                resp = client.get(
+                    f"{base}/collections",
+                    params={"q": query, "limit": min(max_results, _MAX_RESULTS)},
+                )
+                if resp.status_code == 400:
+                    raise ValueError("Server does not support q= parameter")
+                resp.raise_for_status()
+                data = resp.json()
+                collections = data.get("collections", data if isinstance(data, list) else [])
+                results = [_collection_to_geodata(c, backend) for c in collections]
+                if results:
+                    return results
+                # Zero server-side results — fall through to client-side fallback
+            except (ValueError, httpx.HTTPStatusError):
+                pass
+
+            # --- Attempt 2: client-side substring filter ---
+            resp = client.get(f"{base}/collections", params={"limit": _MAX_RESULTS})
+            resp.raise_for_status()
+            data = resp.json()
+            all_collections = data.get("collections", data if isinstance(data, list) else [])
+            q = query.lower()
+            matched = [
+                c
+                for c in all_collections
+                if q in (c.get("title") or "").lower()
+                or q in (c.get("description") or "").lower()
+                or q in (c.get("id") or "").lower()
+            ]
+            return [_collection_to_geodata(c, backend) for c in matched[:max_results]]
+
+    except httpx.ConnectError as exc:
+        logger.warning("OGC API backend %s: connection error — %s", backend.name, exc)
+        raise
+    except ssl.SSLError as exc:
+        logger.warning("OGC API backend %s: SSL error — %s", backend.name, exc)
+        raise
+    except httpx.TimeoutException as exc:
+        logger.warning("OGC API backend %s: timeout — %s", backend.name, exc)
+        raise
+    except Exception as exc:
+        logger.warning("OGC API backend %s: unexpected error — %s", backend.name, exc)
+        raise
+
+
+@tool
+def search_ogcapi_layers(
+    state: Annotated[GeoDataAgentState, InjectedState],
+    tool_call_id: Annotated[str, InjectedToolCallId],
+    query: str,
+    max_results: int = 20,
+) -> Union[Dict[str, Any], Command]:
+    """Search for geospatial layers on configured OGC API servers.
+
+    Use this when the user asks for layers or datasets from an OGC API endpoint.
+    Searches collection title, description, and id for the given query.
+
+    query: natural-language search string, e.g. "rivers Germany"
+    max_results: maximum number of results to return per backend (default 20)
+    """
+    return _search_ogcapi_layers_impl(
+        state=state, tool_call_id=tool_call_id, query=query, max_results=max_results
+    )
+
+
+def _search_ogcapi_layers_impl(
+    state: GeoDataAgentState,
+    tool_call_id: str,
+    query: str,
+    max_results: int = 20,
+) -> Union[Dict[str, Any], Command]:
+    settings = state.get("options")
+    snapshot: Optional[SettingsSnapshot] = None
+    if isinstance(settings, SettingsSnapshot):
+        snapshot = settings
+    elif isinstance(settings, dict):
+        try:
+            snapshot = SettingsSnapshot.model_validate(settings, strict=False)
+        except Exception:
+            snapshot = None
+
+    if not snapshot or not snapshot.ogcapi_backends:
+        return ToolMessage(
+            content="No OGC API backends configured. Add at least one backend in the settings.",
+            tool_call_id=tool_call_id,
+        )
+
+    enabled_backends = [b for b in snapshot.ogcapi_backends if b.enabled]
+    if not enabled_backends:
+        return ToolMessage(
+            content="All configured OGC API backends are disabled.",
+            tool_call_id=tool_call_id,
+        )
+
+    all_results: List[GeoDataObject] = []
+    errors: List[str] = []
+
+    for backend in enabled_backends:
+        try:
+            results = _search_backend(backend, query, max_results)
+            all_results.extend(results)
+        except Exception as exc:
+            errors.append(f"{backend.name}: {exc}")
+
+    if not all_results and errors:
+        return ToolMessage(
+            content=(
+                "Could not reach any OGC API backend. Errors:\n"
+                + "\n".join(f"- {e}" for e in errors)
+            ),
+            tool_call_id=tool_call_id,
+        )
+
+    if not all_results:
+        msg = f'No collections found matching "{query}"'
+        if errors:
+            msg += f" (some backends unreachable: {', '.join(errors)})"
+        return ToolMessage(content=msg + ".", tool_call_id=tool_call_id)
+
+    summary_lines = [f'Found {len(all_results)} collection(s) matching "{query}":']
+    for obj in all_results:
+        summary_lines.append(f"- **{obj.title}**: {obj.description or '(no description)'}")
+    if errors:
+        summary_lines.append(f"\n⚠️ Could not reach: {', '.join(errors)}")
+
+    return Command(
+        update={
+            "geodata_last_results": all_results,
+            "messages": [
+                ToolMessage(
+                    content="\n".join(summary_lines),
+                    tool_call_id=tool_call_id,
+                )
+            ],
+        }
+    )

--- a/backend/services/tools/ogcapi_tools.py
+++ b/backend/services/tools/ogcapi_tools.py
@@ -10,6 +10,7 @@ falls back to listing all collections and filtering client-side via substring
 match on ``title`` and ``description``.
 """
 
+import hashlib
 import logging
 import ssl
 import uuid
@@ -85,8 +86,10 @@ def _collection_to_geodata(
     col_id = collection.get("id", "")
     access_url = _pick_access_url(collection, backend.url)
     bbox_wkt = _extract_bbox_wkt(collection)
+    # Stable deterministic ID so the same collection is deduplicated in agent state.
+    stable_id = str(uuid.UUID(hashlib.sha1(f"{backend.name}:{col_id}".encode()).hexdigest()[:32]))
     return GeoDataObject(
-        id=str(uuid.uuid4()),
+        id=stable_id,
         name=col_id,
         title=collection.get("title") or col_id or "Untitled",
         description=collection.get("description") or "",
@@ -129,7 +132,7 @@ def _search_backend(
                 resp.raise_for_status()
                 data = resp.json()
                 collections = data.get("collections", data if isinstance(data, list) else [])
-                results = [_collection_to_geodata(c, backend) for c in collections]
+                results = [_collection_to_geodata(c, backend) for c in collections[:max_results]]
                 if results:
                     return results
                 # Zero server-side results — fall through to client-side fallback
@@ -171,7 +174,7 @@ def search_ogcapi_layers(
     tool_call_id: Annotated[str, InjectedToolCallId],
     query: str,
     max_results: int = 20,
-) -> Union[Dict[str, Any], Command]:
+) -> Union[Dict[str, Any], Command, ToolMessage]:
     """Search for geospatial layers on configured OGC API servers.
 
     Use this when the user asks for layers or datasets from an OGC API endpoint.
@@ -190,7 +193,7 @@ def _search_ogcapi_layers_impl(
     tool_call_id: str,
     query: str,
     max_results: int = 20,
-) -> Union[Dict[str, Any], Command]:
+) -> Union[Dict[str, Any], Command, ToolMessage]:
     settings = state.get("options")
     snapshot: Optional[SettingsSnapshot] = None
     if isinstance(settings, SettingsSnapshot):

--- a/backend/tests/test_ogcapi_tools.py
+++ b/backend/tests/test_ogcapi_tools.py
@@ -1,0 +1,317 @@
+"""Unit tests for the OGC API layer search tool.
+
+All HTTP calls are mocked via unittest.mock so no network access is needed.
+"""
+
+from contextlib import contextmanager
+from typing import Any, Dict, List
+from unittest.mock import MagicMock, patch
+
+import pytest
+from langchain_core.messages import ToolMessage
+from langgraph.types import Command
+
+from models.geodata import DataType
+from models.settings_model import (
+    ModelSettings,
+    OGCAPIBackend,
+    SettingsSnapshot,
+)
+from models.states import GeoDataAgentState
+from services.tools.ogcapi_tools import (
+    _collection_to_geodata,
+    _pick_access_url,
+    _search_ogcapi_layers_impl,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+MOCK_BACKEND = OGCAPIBackend(
+    url="https://ogcapi.example.com/v1",
+    name="Test OGC API",
+    enabled=True,
+)
+
+MOCK_BACKEND_DISABLED = OGCAPIBackend(
+    url="https://ogcapi.example.com/v1",
+    name="Disabled Backend",
+    enabled=False,
+)
+
+
+def _make_collection(
+    col_id: str,
+    title: str,
+    description: str = "",
+    bbox: List[float] | None = None,
+    links: List[Dict[str, Any]] | None = None,
+) -> Dict[str, Any]:
+    col: Dict[str, Any] = {"id": col_id, "title": title, "description": description}
+    if bbox:
+        col["extent"] = {"spatial": {"bbox": [bbox]}}
+    if links:
+        col["links"] = links
+    return col
+
+
+def _make_snapshot(backends: List[OGCAPIBackend]) -> SettingsSnapshot:
+    return SettingsSnapshot(
+        geoserver_backends=[],
+        ogcapi_backends=backends,
+        mcp_servers=[],
+        model_settings=ModelSettings(
+            model_provider="openai",
+            model_name="gpt-4",
+            max_tokens=1000,
+            system_prompt="",
+        ),
+        tools=[],
+    )
+
+
+def _make_state(snapshot: SettingsSnapshot) -> GeoDataAgentState:
+    return GeoDataAgentState(
+        messages=[],
+        geodata_layers=[],
+        options=snapshot,
+    )
+
+
+def _mock_http_response(json_data: Any, status_code: int = 200) -> MagicMock:
+    """Build a mock httpx Response."""
+    mock_resp = MagicMock()
+    mock_resp.status_code = status_code
+    mock_resp.json.return_value = json_data
+    if status_code >= 400:
+        import httpx
+
+        mock_resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "error", request=MagicMock(), response=mock_resp
+        )
+    else:
+        mock_resp.raise_for_status = MagicMock()
+    return mock_resp
+
+
+@contextmanager
+def _patch_client(responses: List[MagicMock]):
+    """Context manager that patches _make_client to return a mock httpx.Client.
+
+    ``responses`` is consumed in order — one response per client.get() call.
+    """
+    mock_client = MagicMock()
+    mock_client.__enter__ = MagicMock(return_value=mock_client)
+    mock_client.__exit__ = MagicMock(return_value=False)
+    mock_client.get.side_effect = responses
+
+    with patch("services.tools.ogcapi_tools._make_client", return_value=mock_client):
+        yield mock_client
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_pick_access_url_tiles_link():
+    col = _make_collection(
+        "rivers",
+        "Rivers",
+        links=[
+            {"rel": "tiles", "href": "https://example.com/tiles"},
+            {"rel": "items", "href": "https://example.com/items"},
+        ],
+    )
+    assert _pick_access_url(col, "https://example.com") == "https://example.com/tiles"
+
+
+@pytest.mark.unit
+def test_pick_access_url_items_link_when_no_tiles():
+    col = _make_collection(
+        "rivers",
+        "Rivers",
+        links=[{"rel": "items", "href": "https://example.com/items"}],
+    )
+    assert _pick_access_url(col, "https://example.com") == "https://example.com/items"
+
+
+@pytest.mark.unit
+def test_pick_access_url_fallback_to_constructed():
+    col = _make_collection("rivers", "Rivers")
+    result = _pick_access_url(col, "https://example.com/v1")
+    assert result == "https://example.com/v1/collections/rivers/items"
+
+
+@pytest.mark.unit
+def test_collection_to_geodata_maps_fields():
+    col = _make_collection(
+        "kba",
+        "Key Biodiversity Areas",
+        description="Global KBA dataset",
+        bbox=[-180.0, -90.0, 180.0, 90.0],
+    )
+    obj = _collection_to_geodata(col, MOCK_BACKEND)
+    assert obj.title == "Key Biodiversity Areas"
+    assert obj.description == "Global KBA dataset"
+    assert obj.data_type == DataType.LAYER
+    assert obj.data_source == "ogcapi"
+    assert obj.name == "kba"
+    assert obj.data_source_id == "Test OGC API"
+    assert obj.data_link is not None
+    assert obj.bounding_box is not None
+    assert "POLYGON" in obj.bounding_box
+    assert obj.properties["collection_id"] == "kba"
+    assert obj.properties["backend_name"] == "Test OGC API"
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: tool integration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_search_returns_matching_collections():
+    """Server-side q= search returns 2 collections → 2 GeoDataObjects."""
+    collections = [
+        _make_collection("rivers", "Rivers Germany", "German river network"),
+        _make_collection("streams", "Streams Germany", "Small streams"),
+    ]
+    resp = _mock_http_response({"collections": collections})
+
+    snapshot = _make_snapshot([MOCK_BACKEND])
+    state = _make_state(snapshot)
+
+    with _patch_client([resp]):
+        result = _search_ogcapi_layers_impl(
+            state=state, tool_call_id="test-call-id", query="rivers", max_results=20
+        )
+
+    assert isinstance(result, Command)
+    geo_results = result.update["geodata_last_results"]
+    assert len(geo_results) == 2
+    assert geo_results[0].title == "Rivers Germany"
+    assert geo_results[1].title == "Streams Germany"
+
+
+@pytest.mark.unit
+def test_search_no_backends_configured():
+    """Empty ogcapi_backends list → ToolMessage with clear error."""
+    snapshot = _make_snapshot([])
+    state = _make_state(snapshot)
+
+    result = _search_ogcapi_layers_impl(
+        state=state, tool_call_id="test-call-id", query="rivers", max_results=20
+    )
+
+    assert isinstance(result, ToolMessage)
+    assert "No OGC API backends configured" in result.content
+
+
+@pytest.mark.unit
+def test_search_backend_disabled():
+    """All backends disabled → ToolMessage with appropriate error."""
+    snapshot = _make_snapshot([MOCK_BACKEND_DISABLED])
+    state = _make_state(snapshot)
+
+    result = _search_ogcapi_layers_impl(
+        state=state, tool_call_id="test-call-id", query="rivers", max_results=20
+    )
+
+    assert isinstance(result, ToolMessage)
+    assert "disabled" in result.content.lower()
+
+
+@pytest.mark.unit
+def test_search_q_fallback_on_400():
+    """HTTP 400 on q= → tool falls back to listing all + client-side filter."""
+    bad_resp = _mock_http_response({}, status_code=400)
+
+    all_collections = [
+        _make_collection("rivers", "Rivers", "German rivers"),
+        _make_collection("airports", "Airports", "International airports"),
+    ]
+    good_resp = _mock_http_response({"collections": all_collections})
+
+    snapshot = _make_snapshot([MOCK_BACKEND])
+    state = _make_state(snapshot)
+
+    with _patch_client([bad_resp, good_resp]):
+        result = _search_ogcapi_layers_impl(
+            state=state, tool_call_id="test-call-id", query="rivers", max_results=20
+        )
+
+    assert isinstance(result, Command)
+    geo_results = result.update["geodata_last_results"]
+    # Only the "rivers" collection matches the query "rivers"
+    assert len(geo_results) == 1
+    assert geo_results[0].title == "Rivers"
+
+
+@pytest.mark.unit
+def test_search_ssl_error_handled():
+    """SSL error → graceful ToolMessage error, does not raise."""
+    import ssl
+
+    snapshot = _make_snapshot([MOCK_BACKEND])
+    state = _make_state(snapshot)
+
+    mock_client = MagicMock()
+    mock_client.__enter__ = MagicMock(return_value=mock_client)
+    mock_client.__exit__ = MagicMock(return_value=False)
+    mock_client.get.side_effect = ssl.SSLError("certificate verify failed")
+
+    with patch("services.tools.ogcapi_tools._make_client", return_value=mock_client):
+        result = _search_ogcapi_layers_impl(
+            state=state, tool_call_id="test-call-id", query="rivers", max_results=20
+        )
+
+    assert isinstance(result, ToolMessage)
+    assert "Test OGC API" in result.content
+
+
+@pytest.mark.unit
+def test_search_maps_tiles_link():
+    """Collection with a tiles link → data_link set to tiles URL."""
+    collections = [
+        _make_collection(
+            "wdpa",
+            "WDPA Protected Areas",
+            links=[
+                {"rel": "tiles", "href": "https://ogcapi.example.com/v1/collections/wdpa/tiles"}
+            ],
+        )
+    ]
+    resp = _mock_http_response({"collections": collections})
+
+    snapshot = _make_snapshot([MOCK_BACKEND])
+    state = _make_state(snapshot)
+
+    with _patch_client([resp]):
+        result = _search_ogcapi_layers_impl(
+            state=state, tool_call_id="test-call-id", query="wdpa", max_results=20
+        )
+
+    assert isinstance(result, Command)
+    geo_results = result.update["geodata_last_results"]
+    assert len(geo_results) == 1
+    assert geo_results[0].data_link == "https://ogcapi.example.com/v1/collections/wdpa/tiles"
+
+
+@pytest.mark.unit
+def test_search_no_results_returns_tool_message():
+    """Server returns empty list → ToolMessage with no-results message."""
+    resp = _mock_http_response({"collections": []})
+
+    snapshot = _make_snapshot([MOCK_BACKEND])
+    state = _make_state(snapshot)
+
+    with _patch_client([resp, _mock_http_response({"collections": []})]):
+        result = _search_ogcapi_layers_impl(
+            state=state, tool_call_id="test-call-id", query="xyz_nonexistent", max_results=20
+        )
+
+    assert isinstance(result, ToolMessage)
+    assert "No collections found" in result.content


### PR DESCRIPTION
## Summary

Implements nalamap/nalamap#224 — adds a `search_ogcapi_layers` agent tool that queries configured OGC API servers for collections matching a natural-language query.

## Changes

### `backend/models/settings_model.py`
- New `OGCAPIBackend` Pydantic model (url, name, description, enabled, allow_insecure)
- Added `ogcapi_backends: List[OGCAPIBackend]` field to `SettingsSnapshot` (default empty list — backwards-compatible)

### `backend/services/tools/ogcapi_tools.py` (new file)
- `search_ogcapi_layers` `@tool` — queries all enabled OGC API backends
- Server-side `q=` full-text search attempted first (OGC API Common Part 2)
- Falls back to listing all collections + client-side substring filter on `title`, `description`, and `id` when server returns HTTP 400
- Graceful per-backend error handling: SSL, connection, timeout errors don't abort other backends
- Maps collections to `GeoDataObject` with tiles link preferred over items link

### `backend/services/default_agent_settings.py`
- Import and register `search_ogcapi_layers` in `TOOL_METADATA` and `DEFAULT_AVAILABLE_TOOLS`
- Added tool entry to `DEFAULT_SYSTEM_PROMPT` under DATA RETRIEVAL section

### `backend/tests/test_ogcapi_tools.py` (new file)
- 11 unit tests (marker: `unit`), all HTTP calls mocked — no network access
- Covers: server-side search, no backends, disabled backends, HTTP 400 fallback, SSL errors, tiles link mapping, no results

## Acceptance Criteria

- [x] `search_ogcapi_layers` tool registered and visible in session settings
- [x] Agent can find and display collections from a configured OGC API backend given a natural-language query
- [x] Graceful degradation when server does not support `q=` parameter (client-side fallback)
- [x] All unit tests pass (`poetry run python -m pytest tests/test_ogcapi_tools.py -m unit`)
- [x] Flake8 and Black pass

## Dependency

Requires nalamap/nala-ogcapi-server#21 (`q=` full-text search) deployed to benefit from server-side filtering. Tool continues to work via client-side fallback when server does not support `q=`.

Closes #224